### PR TITLE
Intellij Patches to Maven projects

### DIFF
--- a/fcrepo-common/pom.xml
+++ b/fcrepo-common/pom.xml
@@ -42,6 +42,7 @@
 
         <configuration>
           <sourceDirectory>${basedir}/../resources/wsdl</sourceDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources/axistools</outputDirectory>
           <testCases>false</testCases>
           <serverSide>true</serverSide>
           <skeletonDeploy>true</skeletonDeploy>
@@ -163,7 +164,7 @@
             <configuration>
               <mainClass>org.fcrepo.generate.BuildAxisStubWrapper</mainClass>
               <arguments>
-                <argument>${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/management/FedoraAPIMBindingSOAPHTTPStub.java</argument>
+                <argument>${project.build.directory}/generated-sources/axistools/org/fcrepo/server/management/FedoraAPIMBindingSOAPHTTPStub.java</argument>
                 <argument>${project.build.sourceDirectory}/org/fcrepo/common/generate/FedoraStubWrapper.template</argument>
                 <argument>org.fcrepo.client</argument>
                 <argument>APIMStubWrapper</argument>
@@ -181,7 +182,7 @@
             <configuration>
               <mainClass>org.fcrepo.generate.BuildAxisStubWrapper</mainClass>
               <arguments>
-                <argument>${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/FedoraAPIABindingSOAPHTTPStub.java</argument>
+                <argument>${project.build.directory}/generated-sources/axistools/org/fcrepo/server/access/FedoraAPIABindingSOAPHTTPStub.java</argument>
                 <argument>${project.build.sourceDirectory}/org/fcrepo/common/generate/FedoraStubWrapper.template</argument>
                 <argument>org.fcrepo.client</argument>
                 <argument>APIAStubWrapper</argument>
@@ -240,20 +241,20 @@
             <configuration>
               <tasks>
                 <replace
-                  file="${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/management/deploy.wsdd"
+                  file="${project.build.directory}/generated-sources/axistools/org/fcrepo/server/management/deploy.wsdd"
                   token="Fedora-API-M-Port-SOAPHTTP" value="management" />
                 <replace
-                  file="${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/management/deploy.wsdd"
+                  file="${project.build.directory}/generated-sources/axistools/org/fcrepo/server/management/deploy.wsdd"
                   token="*&quot;/&gt;"
                   value="*&quot;/&gt;&lt;parameter name=&quot;scope&quot; value=&quot;application&quot;/&gt;" />
                 <replace
-                  file="${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/deploy.wsdd"
+                  file="${project.build.directory}/generated-sources/axistools/org/fcrepo/server/access/deploy.wsdd"
                   token="Fedora-API-A-Port-SOAPHTTP" value="access" />
                 <replace
-                  file="${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/management/undeploy.wsdd"
+                  file="${project.build.directory}/generated-sources/axistools/org/fcrepo/server/management/undeploy.wsdd"
                   token="Fedora-API-M-Port-SOAPHTTP" value="management" />
                 <replace
-                  file="${project.build.directory}/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/undeploy.wsdd"
+                  file="${project.build.directory}/generated-sources/axistools/org/fcrepo/server/access/undeploy.wsdd"
                   token="Fedora-API-A-Port-SOAPHTTP" value="access" />
               </tasks>
             </configuration>

--- a/fcrepo-installer/src/main/assembly/fedora-home.xml
+++ b/fcrepo-installer/src/main/assembly/fedora-home.xml
@@ -293,7 +293,7 @@
 
     <!-- Common entries -->
     <fileSet>
-      <directory>../fcrepo-common/target/generated-sources/axistools/wsdl2java/org/fcrepo/server/management</directory>
+      <directory>../fcrepo-common/target/generated-sources/axistools/org/fcrepo/server/management</directory>
       <outputDirectory>/server/fedora-internal-use/deploy</outputDirectory>
       <includes>
         <include>deploy.wsdd</include>
@@ -313,12 +313,12 @@
     </file>
 
     <file>
-      <source>../fcrepo-common/target/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/deploy.wsdd</source>
+      <source>../fcrepo-common/target/generated-sources/axistools/org/fcrepo/server/access/deploy.wsdd</source>
       <outputDirectory>/server/fedora-internal-use/deploy</outputDirectory>
       <destName>deployAPI-A.wsdd</destName>
     </file>
     <file>
-      <source>../fcrepo-common/target/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/undeploy.wsdd</source>
+      <source>../fcrepo-common/target/generated-sources/axistools/org/fcrepo/server/access/undeploy.wsdd</source>
       <outputDirectory>/server/fedora-internal-use/deploy</outputDirectory>
       <destName>undeployAPI-A.wsdd</destName>
     </file>

--- a/fcrepo-webapp/fcrepo-webapp-fedora/pom.xml
+++ b/fcrepo-webapp/fcrepo-webapp-fedora/pom.xml
@@ -32,9 +32,9 @@
                   classpathref="maven.compile.classpath" dir="${project.build.outputDirectory}">
                   <arg value="server" />
                   <arg
-                    value="${basedir}/../../fcrepo-common/target/generated-sources/axistools/wsdl2java/org/fcrepo/server/management/deploy.wsdd" />
+                    value="${basedir}/../../fcrepo-common/target/generated-sources/axistools/org/fcrepo/server/management/deploy.wsdd" />
                   <arg
-                    value="${basedir}/../../fcrepo-common/target/generated-sources/axistools/wsdl2java/org/fcrepo/server/access/deploy.wsdd" />
+                    value="${basedir}/../../fcrepo-common/target/generated-sources/axistools/org/fcrepo/server/access/deploy.wsdd" />
                   <sysproperty key="logback.configurationFile"
                     value="${basedir}/src/test/resources/logback.xml" />
                 </java>


### PR DESCRIPTION
Redirect output of Axistools / wsdl2java, so that it goes into the directory that IntelliJ expects (and fix all other references in the project).

This allows IntelliJ IDEA to load the projects, without complaining about missing classes that are generated by wsdl2java.
