### PR TITLE
FCREPO-1106

### DIFF
--- a/fcrepo-server/src/main/java/org/fcrepo/server/management/DefaultManagement.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/management/DefaultManagement.java
@@ -915,7 +915,7 @@ public class DefaultManagement
             } else {
                 checksumType = Datastream.validateChecksumType(checksumType);
             }
-            if ("DC".equals(datastreamId)){
+            if (dsContent != null && "DC".equals(datastreamId)){
                 DCFields audited = new DCFields(dsContent);
                 try {
                     dsContent = new ByteArrayInputStream(audited.getAsXML(pid).getBytes("UTF-8"));


### PR DESCRIPTION
Added check when updating a DC datastream. If the DC datastream data isn't sent
using the REST API modifyDatastream request we were getting an error.

This used to work in 3.4.2, but was broken in 3.5 and 3.6.
