### PR TITLE
FCREPO-1192: always parse content-length as a long; RestUtils is static code

### DIFF
--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/FedoraObjectsResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/FedoraObjectsResource.java
@@ -463,9 +463,8 @@ public class FedoraObjectsResource extends BaseRestResource {
             InputStream is = null;
 
             // Determine if content is provided
-            RestUtil restUtil = new RestUtil();
             RequestContent content =
-                    restUtil.getRequestContent(m_servletRequest, headers);
+                    RestUtil.getRequestContent(m_servletRequest, headers);
             if (content != null && content.getContentStream() != null) {
                 if (ignoreMime) {
                     is = content.getContentStream();


### PR DESCRIPTION
Pretty straightforward: we should never rely on the ServletRequest#getContentLength method, or parse the value of the Content-Length header as int data. I made RestUtil static because it has no state, so it's just junk object creation. There's also some logging.
