### PR TITLE
Add FEDORA_WEBAPP_HOME environment variable

### DIFF
--- a/fcrepo-server/src/main/resources/scripts/bat/server/env-server.bat
+++ b/fcrepo-server/src/main/resources/scripts/bat/server/env-server.bat
@@ -33,11 +33,9 @@ exit /B 1
 :gotCatalinaHome
 
 if not "%FEDORA_WEBAPP_HOME%" == "" goto gotFedoraWebappHome
-set WEBINF="%CATALINA_HOME%\webapps\%WEBAPP_NAME%\WEB-INF"
-goto gotWebinf
+set FEDORA_WEBAPP_HOME="%CATALINA_HOME%\webapps\%WEBAPP_NAME%"
 :gotFedoraWebappHome
 set WEBINF="%FEDORA_WEBAPP_HOME%\WEB-INF"
-:gotWebinf
 
 if exist "%WEBINF%" goto webInfExists
 echo ERROR: Fedora could not be found in the specified path, please set the environment variable FEDORA_WEBAPP_HOME

--- a/fcrepo-server/src/main/resources/scripts/sh/server/env-server.sh
+++ b/fcrepo-server/src/main/resources/scripts/sh/server/env-server.sh
@@ -31,10 +31,10 @@ if [ -z "$CATALINA_HOME" ]; then
 fi
 
 if [ -z "$FEDORA_WEBAPP_HOME" ]; then
-  webinf="$CATALINA_HOME"/webapps/$webapp_name/WEB-INF                                                                                               
-else
-  webinf="$FEDORA_WEBAPP_HOME"/WEB-INF
+  FEDORA_WEBAPP_HOME="$CATALINA_HOME"/webapps/$webapp_name
 fi
+
+webinf="$FEDORA_WEBAPP_HOME"/WEB-INF
 
 if [ ! -d "$webinf" ]; then
 	echo "ERROR: Fedora could not be found in the specified path, please set the environment variable FEDORA_WEBAPP_HOME"


### PR DESCRIPTION
Add FEDORA_WEBAPP_HOME environment variable to env-server.sh and env-server.bat, so that Fedora webapp library files installed in a non-standard location can still be found by the server command line utility scripts.
