### PR TITLE
3.8.1 javadoc

### DIFF
--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/FTypeDialog.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/FTypeDialog.java
@@ -12,10 +12,10 @@ import javax.swing.JOptionPane;
  * sSefs, sDeps, data objects (any combination).
  * 
  * <p>Result will come back as string consisting of combination of "D", "M", 
- * and "O" characters, respectively, if selected.
+ * and "O" characters, respectively, if selected.</p>
  * 
  * @author Chris Wilper
- * @deprecated.  May replace/refactor with something that selects content models
+ * @deprecated  May replace/refactor with something that selects content models
  */
 public class FTypeDialog
         extends JDialog {

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/WatchPrintStream.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/WatchPrintStream.java
@@ -9,7 +9,7 @@ import java.io.PrintStream;
 
 /**
  * A PrintStream that sends its output to Administrator.WATCH_AREA, the
- * JTextArea of the Tools->Advanced->STDOUT/STDERR window. This is used for
+ * JTextArea of the Tools-&gt;Advanced-&gt;STDOUT/STDERR window. This is used for
  * redirecting System.out/err output to the UI.
  * 
  * @author Chris Wilper

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/console/ArrayInputPanel.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/console/ArrayInputPanel.java
@@ -11,7 +11,6 @@ import javax.swing.JLabel;
 /**
  * @author Chris Wilper
  * @param <T>
- * @param <T>
  */
 public class ArrayInputPanel<T>
         extends InputPanel<T[]> {

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/objecteditor/types/MethodDefinition.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/objecteditor/types/MethodDefinition.java
@@ -44,7 +44,7 @@ public class MethodDefinition {
      *                       label="PARAMETER_LABEL"(0-1)
      *                    required="IS_REQUIRED"
      *                defaultValue="DEFAULT_VALUE"&gt;
-     *         &lt;ValidParmValues>(0-1)
+     *         &lt;ValidParmValues&gt;(0-1)
      *             &lt;ValidParm value="VALID_VALUE_1"/&gt;(0-)
      *         &lt;/ValidParmValues&gt;
      *     &lt;/UserInputParm&gt;(0-) 

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/test/ScalabilityTests.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/test/ScalabilityTests.java
@@ -140,7 +140,7 @@ public class ScalabilityTests
     /**
      * Runs the ingest over the set number of batches
      * or runs continuously if the number of batches
-     * is <= 0.
+     * is &lt;= 0.
      */
     public void runIngestTest() throws Exception {
         if(numBatches > 0) {

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/utility/validate/package-info.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/utility/validate/package-info.java
@@ -12,12 +12,12 @@
  * This package contains the basic Validator framework, with core classes and interfaces.
  * </p>
  * <p>
- * <code>org.fcrepo.client.utility.validate.process</code> contains a client-side {@link ValidatorProcess}
+ * <code>org.fcrepo.client.utility.validate.process</code> contains a client-side {@link org.fcrepo.client.utility.validate.process.ValidatorProcess}
  * that parses the command line arguments, queries Fedora for the requested objects, validates them.
- * It also has a simple implementation of {@link ValidatorResult}.
+ * It also has a simple implementation of {@link org.fcrepo.client.utility.validate.ValidationResult}.
  * </p>
  * <p>
- * <code>org.fcrepo.client.utility.validate.remote</code> contains an implementation of {@link ObjectSource}
+ * <code>org.fcrepo.client.utility.validate.remote</code> contains an implementation of {@link org.fcrepo.client.utility.validate.ObjectSource}
  * that can be used to access a remote instance of Fedora, with helper classes.
  * </p>
  * <p>

--- a/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/utility/validate/remote/TypeUtility.java
+++ b/fcrepo-client/fcrepo-client-admin/src/main/java/org/fcrepo/client/utility/validate/remote/TypeUtility.java
@@ -38,7 +38,7 @@ public class TypeUtility {
 
     /**
      * Convert a local {@link FieldSearchQuery} into a WSDL-style
-     * {@link org.fcrepo.server.types.mtom.gen.FieldSearchQuery FieldSearchQuery}.
+     * {@link org.fcrepo.server.types.gen.FieldSearchQuery FieldSearchQuery}.
      */
     public static org.fcrepo.server.types.gen.FieldSearchQuery convertFieldSearchQueryToGenFieldSearchQuery(FieldSearchQuery fsq) {
         List<org.fcrepo.server.types.gen.Condition> genConditions =
@@ -56,7 +56,7 @@ public class TypeUtility {
 
     /**
      * Convert a {@link List} of local {@link Condition}s into an array of
-     * WSDL-style {@link org.fcrepo.server.types.mtom.gen.Condition Condition}s.
+     * WSDL-style {@link org.fcrepo.server.types.gen.Condition Condition}s.
      */
     public static List<org.fcrepo.server.types.gen.Condition> convertConditionsListToGenConditionsArray(List<Condition> conditions) {
         List<org.fcrepo.server.types.gen.Condition> genConditions =
@@ -71,7 +71,7 @@ public class TypeUtility {
 
     /**
      * Convert a local {@link Condition} into a WSDL-style
-     * {@link org.fcrepo.server.types.mtom.gen.Condition Condition}.
+     * {@link org.fcrepo.server.types.gen.Condition Condition}.
      */
     public static org.fcrepo.server.types.gen.Condition convertConditionToGenCondition(Condition condition) {
         String opAbbr = condition.getOperator().getAbbreviation();
@@ -92,7 +92,7 @@ public class TypeUtility {
 
     /**
      * Convert a WSDL-style
-     * {@link org.fcrepo.server.types.mtom.gen.FieldSearchResult FieldSearchResult} to a
+     * {@link org.fcrepo.server.types.gen.FieldSearchResult FieldSearchResult} to a
      * local {@link FieldSearchResult}.
      */
     public static FieldSearchResult convertGenFieldSearchResultToFieldSearchResult(org.fcrepo.server.types.gen.FieldSearchResult fsr) {
@@ -124,7 +124,7 @@ public class TypeUtility {
 
     /**
      * Convert an array of WSDL-style
-     * {@link org.fcrepo.server.types.mtom.gen.ObjectFields ObjectFields} objects to a
+     * {@link org.fcrepo.server.types.gen.ObjectFields ObjectFields} objects to a
      * {@link List} of local {@link ObjectFields} objects.
      */
     public static List<ObjectFields> convertGenObjectFieldsArrayToObjectFieldsList(org.fcrepo.server.types.gen.ObjectFields[] objectFields) {
@@ -137,7 +137,7 @@ public class TypeUtility {
 
     /**
      * Convert a WSDL-style
-     * {@link org.fcrepo.server.types.mtom.gen.ObjectFields ObjectFields} object to a
+     * {@link org.fcrepo.server.types.gen.ObjectFields ObjectFields} object to a
      * local {@link ObjectFields} object.
      */
     public static ObjectFields convertGenObjectFieldsToObjectFields(org.fcrepo.server.types.gen.ObjectFields source) {

--- a/fcrepo-client/fcrepo-client-admin/src/test/java/org/fcrepo/mock/client/utility/validate/MockObjectSource.java
+++ b/fcrepo-client/fcrepo-client-admin/src/test/java/org/fcrepo/mock/client/utility/validate/MockObjectSource.java
@@ -123,9 +123,6 @@ public class MockObjectSource
     // Un-implemented methods
     // ----------------------------------------------------------------------
 
-    /**
-     * {@inheritDoc}
-     */
     public Iterator<String> findObjectPids(FieldSearchQuery query)
             throws ObjectSourceException {
         // KLUGE Auto-generated method stub

--- a/fcrepo-client/fcrepo-client-messaging/src/main/java/org/fcrepo/client/messaging/JmsMessagingClient.java
+++ b/fcrepo-client/fcrepo-client-messaging/src/main/java/org/fcrepo/client/messaging/JmsMessagingClient.java
@@ -69,7 +69,7 @@ public class JmsMessagingClient implements MessagingClient, MessageListener {
     /**
      * Creates a messaging client
      *
-     * <h4>Client ID</h4>
+     * <h1>Client ID</h1>
      * <p>
      * The clientId provides applications with the opportunity to create
      * multiple messaging clients and track them based on this identifier.
@@ -77,20 +77,22 @@ public class JmsMessagingClient implements MessagingClient, MessageListener {
      * connection for durable subscriptions.
      * </p>
      *
-     * <h4>Message Listener</h4>
+     * <h1>Message Listener</h1>
      * <p>
      * A listener, the onMessage() method of which will be called when a
      * message arrives from the messaging provider. See the documentation
      * for javax.jms.MessageListener for more information.
      * </p>
      *
-     * <h4>Connection Properties</h4>
+     * <h1>Connection Properties</h1>
      *
      * <p>All of the following properties must be included:</p>
-     * <table border="1">
-     *   <th>Property</th>
-     *   <th>Description</th>
-     *   <th>Example Value</th>
+     * <table border="1" summary="JMS Connection Properties">
+     *   <tr>
+     *     <th>Property</th>
+     *     <th>Description</th>
+     *     <th>Example Value</th>
+     *   </tr>
      *   <tr>
      *     <td>java.naming.factory.initial (javax.naming.Context.INITIAL_CONTEXT_FACTORY)</td>
      *     <td>The JNDI initial context factory which will allow lookup of the other attributes</td>
@@ -108,10 +110,12 @@ public class JmsMessagingClient implements MessagingClient, MessageListener {
      *   </tr>
      * </table>
      * <p>One or more of the following properties must be specified:</p>
-     * <table border="1">
-     *   <th>Property Name</th>
-     *   <th>Description</th>
-     *   <th>Example Value</th>
+     * <table border="1" summary="JMS Subscription Properties">
+     *   <tr>
+     *     <th>Property Name</th>
+     *     <th>Description</th>
+     *     <th>Example Value</th>
+     *   </tr>
      *   <tr>
      *     <td>topic.X (where X = name of subscription topic, example - topic.fedoraManagement)</td>
      *     <td>A topic over which notification messages will be provided</td>
@@ -124,7 +128,7 @@ public class JmsMessagingClient implements MessagingClient, MessageListener {
      *   </tr>
      * </table>
      *
-     * <h4>Durable</h4>
+     * <h1>Durable</h1>
      * <p>
      * Specifies whether the topics included in the connection properties should
      * have durable consumers. If set to true, all topics listeners will be
@@ -140,7 +144,7 @@ public class JmsMessagingClient implements MessagingClient, MessageListener {
      * A single MessageListener can be registered as the listener for both clients.
      * </p>
      *
-     * <h4>Message Selector</h4>
+     * <h1>Message Selector</h1>
      * <p>
      * A JMS message selector allows a client to specify, by header field references
      * and property references, the messages it is interested in. Only messages

--- a/fcrepo-common/pom.xml
+++ b/fcrepo-common/pom.xml
@@ -181,6 +181,12 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>mulgara-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -213,6 +219,12 @@
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>1.6.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/fcrepo-common/src/main/java/org/fcrepo/common/Constants.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/Constants.java
@@ -738,7 +738,7 @@ public interface Constants {
          * Once successfully determined, the value is guaranteed not to change
          * during the life of the application.
          *
-         * @returns the value, or <code>null</code> if undefined in any way.
+         * @return String value, or <code>null</code> if undefined in any way.
          */
         public static final String getValue() {
             if (value == null) {

--- a/fcrepo-common/src/main/java/org/fcrepo/common/MalformedPIDException.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/MalformedPIDException.java
@@ -5,7 +5,7 @@
 package org.fcrepo.common;
 
 /**
- * Thrown when a PID is not well-formed. <p/>
+ * <p>Thrown when a PID is not well-formed.</p>
  * 
  * @author Chris Wilper
  */
@@ -16,6 +16,7 @@ public class MalformedPIDException
 
     /**
      * Construct a MalformedPIDException with the given reason.
+     * @param why String
      */
     public MalformedPIDException(String why) {
         super(why);

--- a/fcrepo-common/src/main/java/org/fcrepo/common/PID.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/PID.java
@@ -74,8 +74,10 @@ public class PID {
     }
 
     /**
-     * Alternate constructor that throws an unchecked exception if it's not
+     * Factory method that throws an unchecked exception if it's not
      * well-formed.
+     * @param pidString the String value of the PID
+     * @return PID
      */
     public static PID getInstance(String pidString) {
         try {
@@ -88,6 +90,9 @@ public class PID {
     /**
      * Construct a PID given a filename of the form produced by toFilename(),
      * throwing a MalformedPIDException if it's not well-formed.
+     * @param filenameString default translation of PID to filename
+     * @return PID the PID producing the input filename
+     * @throws MalformedPIDException
      */
     public static PID fromFilename(String filenameString)
             throws MalformedPIDException {
@@ -101,6 +106,9 @@ public class PID {
     /**
      * Return the normalized form of the given pid string, or throw a
      * MalformedPIDException.
+     * @param pidString
+     * @return String normalized version of the pid
+     * @throws MalformedPIDException
      */
     public static String normalize(String pidString)
             throws MalformedPIDException {
@@ -218,6 +226,7 @@ public class PID {
     /**
      * Return the URI form of this PID. This is just the PID, prepended with
      * "info:fedora/".
+     * @return String pid as uri value
      */
     public String toURI() {
         return Constants.FEDORA.uri.concat(m_normalized);

--- a/fcrepo-common/src/main/java/org/fcrepo/common/http/HttpInputStream.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/http/HttpInputStream.java
@@ -96,7 +96,7 @@ public class HttpInputStream
      * if the fighter is not present
      * @param name the header name
      * @param defaultVal the default value
-     * @return
+     * @return String
      */
     public String getResponseHeaderValue(String name, String defaultVal) {
         if (m_response.containsHeader(name)) {

--- a/fcrepo-common/src/main/java/org/fcrepo/common/policy/ActionNamespace.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/policy/ActionNamespace.java
@@ -7,8 +7,8 @@ package org.fcrepo.common.policy;
 import org.jboss.security.xacml.sunxacml.attr.StringAttribute;
 
 /**
- * The Fedora Action XACML namespace.
- * <p/>
+ * <p>The Fedora Action XACML namespace.
+ * </p>
  * <pre>
  * Namespace URI    : urn:fedora:names:fedora:2.1:action
  * </pre>

--- a/fcrepo-common/src/main/java/org/fcrepo/common/xml/format/XMLFormat.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/xml/format/XMLFormat.java
@@ -28,9 +28,9 @@ public class XMLFormat {
      * 
      * @param uri
      *        the URI of the format.
-     * @param xmlNamespace
+     * @param namespace
      *        the primary XML namespace.
-     * @param xsdSchemaLocation
+     * @param xsdLocation
      *        the public location of the XSD schema.
      * @throws IllegalArgumentException
      *         if any parameter is null.

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/Base64.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/Base64.java
@@ -37,7 +37,7 @@ public abstract class Base64 {
      * successful or not.
      *
      * @param in stream to encode
-     * @param encoded bytes, or null if there's an error reading the stream
+     * @return encoded bytes, or null if there's an error reading the stream
      */
     public static byte[] encode(InputStream in) {
         Base64OutputStream out = null;
@@ -84,7 +84,7 @@ public abstract class Base64 {
      * successful or not.
      *
      * @param in stream to encode
-     * @param encoded string, or null if there's an error reading the stream
+     * return encoded string, or null if there's an error reading the stream
      */
     public static String encodeToString(InputStream in) {
         return getString(encode(in));

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/FileUtils.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/FileUtils.java
@@ -29,7 +29,7 @@ public class FileUtils {
      * @param destination
      * @return <code>true</code> if the operation was successful;
      *         <code>false</code> otherwise (which includes a null input).
-     * @see http://java.sun.com/docs/books/performance/1st_edition/html/JPIOPerformance.fm.html#22980
+     * @see "http://java.sun.com/docs/books/performance/1st_edition/html/JPIOPerformance.fm.html#22980"
      */
     public static boolean copy(InputStream source, OutputStream destination) {
         return copy(source, destination, new byte[4096]);
@@ -53,7 +53,7 @@ public class FileUtils {
      * This method should only be used when the ByteBuffer is known to be able to accomodate the input!
      * @param source
      * @param destination
-     * @return
+     * @return success of the operation
      */
     public static boolean copy(InputStream source, ByteBuffer destination) {
         try {
@@ -111,7 +111,7 @@ public class FileUtils {
      *
      * @param prefix
      * @param directory
-     * @return
+     * @return java.io.File temporary directory
      * @throws IOException
      */
     public static File createTempDir(String prefix, File directory) throws IOException {
@@ -218,7 +218,7 @@ public class FileUtils {
      *
      * @param f
      *        the Properties file to parse.
-     * @return a Map<String, String> representing the given Properties file.
+     * @return a Map&lt;String, String&gt; representing the given Properties file.
      * @throws IOException
      * @see java.util.Properties
      * @see java.util.Map

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/MimeTypeUtils.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/MimeTypeUtils.java
@@ -52,8 +52,6 @@ public class MimeTypeUtils {
      * Default MIME type, when a MIME type cannot be determined from a file's
      * extension.
      *
-     * @see #MIMETypeForFile
-     * @see #MIMETypeForFileName
      */
     public static final String DEFAULT_MIME_TYPE = "application/octet-stream";
 
@@ -160,8 +158,6 @@ public class MimeTypeUtils {
      *
      * @param path
      *        path to the file
-     * @param map
-     *        map to load
      */
     private static void loadMIMETypesFile(String path) {
         try {

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/NamespaceContextImpl.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/NamespaceContextImpl.java
@@ -45,7 +45,7 @@ public class NamespaceContextImpl
      *
      * @param prefix2ns a mapping of prefixes to namespaces.
      * @throws IllegalArgumentException if prefix2ns contains
-     * {@value XMLConstants.XML_NS_URI} or {@value XMLConstants.XMLNS_ATTRIBUTE_NS_URI}
+     * {@value XMLConstants#XML_NS_URI} or {@value XMLConstants#XMLNS_ATTRIBUTE_NS_URI}
      */
     public NamespaceContextImpl(Map<String, String> prefix2ns) {
         this();
@@ -102,7 +102,7 @@ public class NamespaceContextImpl
      * @param prefix
      * @param namespaceURI
      * @throws IllegalArgumentException if namespaceURI is one of
-     * {@value XMLConstants.XML_NS_URI} or {@value XMLConstants.XMLNS_ATTRIBUTE_NS_URI}
+     * {@value XMLConstants#XML_NS_URI} or {@value XMLConstants#XMLNS_ATTRIBUTE_NS_URI}
      */
     public void addNamespace(String prefix, String namespaceURI) {
         if (prefix == null || namespaceURI == null) {

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/NormalizedURI.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/NormalizedURI.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  *
  * @author Edwin Shin
  * @since 3.0
- * @see RFC3986
+ * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC3986</a>
  * @version $Id$
  */
 public class NormalizedURI {
@@ -98,7 +98,7 @@ public class NormalizedURI {
 
     /**
      * Case Normalization
-     * @see RFC3986 6.2.2.1
+     * @see "RFC3986 6.2.2.1"
      *
      */
     public void normalizeCase() {
@@ -138,7 +138,7 @@ public class NormalizedURI {
 
     /**
      * Percent-Encoding Normalization
-     * @see RFC3986 6.2.2.2
+     * @see "RFC3986 6.2.2.2"
      *
      */
     public void normalizePercentEncoding() {
@@ -154,7 +154,7 @@ public class NormalizedURI {
 
     /**
      * Path Segment Normalization
-     * @see RFC3986 6.2.2.3
+     * @see "RFC3986 6.2.2.3"
      *
      */
     public void normalizePathSegment() {
@@ -163,7 +163,7 @@ public class NormalizedURI {
 
     /**
      * Scheme-Based Normalization
-     * @see RFC3986 6.2.3
+     * @see "RFC3986 6.2.3"
      *
      */
     public void normalizeByScheme() {
@@ -206,7 +206,7 @@ public class NormalizedURI {
 
     /**
      * Protocol-Based Normalization
-     * @see RFC3986 6.2.4
+     * @see "RFC3986 6.2.4"
      *
      */
     public void normalizeByProtocol() {

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/ReadableCharArrayWriter.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/ReadableCharArrayWriter.java
@@ -11,16 +11,10 @@ public class ReadableCharArrayWriter extends CharArrayWriter {
     
     private boolean closed = false;
     
-    /**
-     * {@inheritDoc}
-     */
     public ReadableCharArrayWriter() {
         super();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     public ReadableCharArrayWriter(int size) {
         super(size);
     }

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/TimestampedCacheEntry.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/TimestampedCacheEntry.java
@@ -26,7 +26,7 @@ public class TimestampedCacheEntry<T> {
 	/**
 	 * Calculate the age since the object was created (or claimed creation)
 	 * and the Current system time
-	 * @return
+     * @return long time since documented creation
 	 */
 	public long age() {
 	    return System.currentTimeMillis() - this.timeStamp;
@@ -36,7 +36,7 @@ public class TimestampedCacheEntry<T> {
 	 * Calculate the age since the object was created (or claimed creation)
 	 * and the passed time as a long. Useful for loop processing of entries.
 	 * @param time
-	 * @return
+	 * @return long time since documented creation
 	 */
     public long ageAt(long time) {
         return time - this.timeStamp;

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/XmlTransformUtility.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/XmlTransformUtility.java
@@ -58,9 +58,9 @@ public class XmlTransformUtility {
         
     /**
      * Convenience method to get a new instance of a TransformerFactory.
-     * If the {@link #TransformerFactory} is an instance of
+     * If the {@link TransformerFactory} is an instance of
      * net.sf.saxon.TransformerFactoryImpl, the attribute
-     * {@link #FeatureKeys.VERSION_WARNING} will be set to false in order to
+     * {@link net.sf.saxon.FeatureKeys#VERSION_WARNING} will be set to false in order to
      * suppress the warning about using an XSLT1 stylesheet with an XSLT2
      * processor.
      *
@@ -105,7 +105,7 @@ public class XmlTransformUtility {
     /**
      * Try to cache parsed Templates, but check for changes on disk
      * @param src
-     * @return
+     * @return Templates
      */
     public static Templates getTemplates(File src) throws TransformerException {
         String key = src.getAbsolutePath();

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/DOM.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/DOM.java
@@ -24,9 +24,9 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Helpers for doing DOM parsing and manipulations.
- * <p/>
- * Ported from the State and University Library  project sbutils.
+ * <p>Helpers for doing DOM parsing and manipulations.
+ * </p><p>
+ * Ported from the State and University Library  project sbutils.</p>
  */
 public class DOM {
 
@@ -158,7 +158,7 @@ public class DOM {
      * Convert the given DOM to an UTF-8 XML String.
      *
      * @param dom                the Document to convert.
-     * @param withXmlDeclaration if trye, an XML-declaration is prepended.
+     * @param withXmlDeclaration if true, an XML-declaration is prepended.
      * @return the dom as an XML String.
      * @throws TransformerException if the dom could not be converted.
      */
@@ -182,19 +182,19 @@ public class DOM {
     }
 
     /**
-     * Create a new {@link XPathSelector} instance with a given namespace
+     * <p>Create a new {@link XPathSelector} instance with a given namespace
      * mapping. The arguments are parsed as
      * {@code prefix1, uri1, prefix2, uri2, ...}.
-     * <p/>
+     * </p><p>
      * If you want to apply XPath expressions without namespaces use the static
      * {@code select*} methods directly on the {@code DOM} class.
-     * <p/>
+     * </p><p>
      * Note that if you want to apply XPath selections on a DOM constructed from
      * either {@link DOM#streamToDOM(InputStream, boolean)} or
      * {@link DOM#stringToDOM(String, boolean)} you must pass
      * {@code namespaceAware=true} as the boolean argument. Namespaced
      * selections will fail on a DOM constructed without namespaces.
-     *
+     * </p>
      * @param nsContext prefix, uri pairs
      * @return a newly allocated {@link XPathSelector}
      * @throws IllegalArgumentException if an uneven number of arguments are
@@ -287,12 +287,12 @@ public class DOM {
     }
 
     /**
-     * Extract the given value from the node as a String or if the value cannot
+     * <p>Extract the given value from the node as a String or if the value cannot
      * be extracted, {@code defaultValue} is returned.
-     * <p/>
+     * </p><p>
      * Example: To get the value of the attribute "foo" in the node, specify
      * "@foo" as the path.
-     * <p/>
+     * </p>
      * Note: This method does not handle namespaces explicitely.
      *
      * @param node         the node with the wanted attribute
@@ -306,12 +306,12 @@ public class DOM {
     }
 
     /**
-     * Extract the given value from the node as a String or if the value cannot
+     * <p>Extract the given value from the node as a String or if the value cannot
      * be extracted, the empty string is returned
-     * <p/>
+     * </p><p>
      * Example: To get the value of the attribute "foo" in the node, specify
      * "@foo" as the path.
-     * <p/>
+     * </p>
      * Note: This method does not handle namespaces explicitely.
      *
      * @param node  the node with the wanted attribute
@@ -324,11 +324,11 @@ public class DOM {
     }
 
     /**
-     * Select the {@link NodeList} with the given XPath.
+     * <p>Select the {@link NodeList} with the given XPath.
      * </p><p>
      * Note: This is a convenience method that logs exceptions instead of
      * throwing them.
-     *
+     * </p>
      * @param node  the root document.
      * @param xpath the xpath for the Node list.
      * @return the NodeList requested or an empty NodeList if unattainable
@@ -338,11 +338,11 @@ public class DOM {
     }
 
     /**
-     * Select the Node with the given XPath.
+     * <p>Select the Node with the given XPath.
      * </p><p>
      * Note: This is a convenience method that logs exceptions instead of
      * throwing them.
-     *
+     * </p>
      * @param dom   the root document.
      * @param xpath the xpath for the node.
      * @return the Node or null if unattainable.

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/DefaultNamespaceContext.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/DefaultNamespaceContext.java
@@ -24,8 +24,8 @@ public class DefaultNamespaceContext implements NamespaceContext {
 
 
     /**
-     * Constructs a NamespaceContext with no default namespace.
-     * <p/>
+     * <p>Constructs a NamespaceContext with no default namespace.
+     * </p>
      * Beware that the default namespace can only be set during
      * construction.
      */
@@ -35,7 +35,6 @@ public class DefaultNamespaceContext implements NamespaceContext {
 
     /**
      * Constructs a NamespaceContext with a default namespace.
-     * <p/>
      *
      * @param defaultNamespaceURI , the default namespace for this context.
      */
@@ -72,11 +71,11 @@ public class DefaultNamespaceContext implements NamespaceContext {
     }
 
     /**
-     * Set or add a namespace to the context and associated it with a prefix.
-     * <p/>
+     * <p>Set or add a namespace to the context and associated it with a prefix.
+     * </p><p>
      * A given prefix can only be associated with one namespace in the context.
      * A namespace can have multiple prefixes.
-     * <p/>
+     * </p>
      * The prefixes: {@code xml}, and {@code xmlns} are reserved and
      * predefined in any context.
      *
@@ -111,7 +110,7 @@ public class DefaultNamespaceContext implements NamespaceContext {
 
 
         if (!this.prefixes.containsKey(prefix)) {
-            return XMLConstants.NULL_NS_URI;
+            return "";
         }
 
         return this.prefixes.get(prefix);
@@ -210,7 +209,7 @@ public class DefaultNamespaceContext implements NamespaceContext {
 
     /**
      * This Iterator wraps any Iterator and makes the remove() method
-     * unsupported.<br>
+     * unsupported.<br></br>
      *
      * @author Hans Lund, State and University Library, Aarhus Denamrk.
      * @version $Id: DefaultNamespaceContext.java,v 1.5 2007/10/04 13:28:21 te Exp $

--- a/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/XPathSelector.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/utilities/xml/XPathSelector.java
@@ -4,9 +4,9 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
- * Interface for doing efficient XPath selections. To obtain an implementation
+ * <p>Interface for doing efficient XPath selections. To obtain an implementation
  * of this interface use {@link DOM#createXPathSelector(String[])}.
- * <p/>
+ * </p>
  * Note that your DOM must be constructed with namespaces explicitly enabled
  * for a namespace aware selector to work properly. You do this either via
  * the {@link DOM#streamToDOM(java.io.InputStream , boolean)} or
@@ -85,12 +85,12 @@ public interface XPathSelector {
     public Boolean selectBoolean(Node node, String xpath);
 
     /**
-     * Extract the given value from the node as a String or if the value cannot
+     * <p>Extract the given value from the node as a String or if the value cannot
      * be extracted, {@code defaultValue} is returned.
-     * <p/>
+     * </p><p>
      * Example: To get the value of the attribute "foo" in the node, specify
      * "@foo" as the path.
-     * <p/>
+     * </p>
      * Note: This method does not handle namespaces explicitely.
      *
      * @param node         the node with the wanted attribute
@@ -102,12 +102,12 @@ public interface XPathSelector {
     public String selectString(Node node, String xpath, String defaultValue);
 
     /**
-     * Extract the given value from the node as a String or if the value cannot
+     * <p>Extract the given value from the node as a String or if the value cannot
      * be extracted, the empty string is returned
-     * <p/>
+     * </p><p>
      * Example: To get the value of the attribute "foo" in the node, specify
      * "@foo" as the path.
-     * <p/>
+     *</p>
      * Note: This method does not handle namespaces explicitely.
      *
      * @param node  the node with the wanted attribute
@@ -118,11 +118,11 @@ public interface XPathSelector {
     public String selectString(Node node, String xpath);
 
     /**
-     * Select the Node list with the given XPath.
+     * <p>Select the Node list with the given XPath.
      * </p><p>
      * Note: This is a convenience method that logs exceptions instead of
      * throwing them.
-     *
+     * </p>
      * @param node  the root document.
      * @param xpath the xpath for the Node list.
      * @return the NodeList requested or an empty NodeList if unattainable
@@ -130,11 +130,11 @@ public interface XPathSelector {
     public NodeList selectNodeList(Node node, String xpath);
 
     /**
-     * Select the Node with the given XPath.
+     * <p>Select the Node with the given XPath.
      * </p><p>
      * Note: This is a convenience method that logs exceptions instead of
      * throwing them.
-     *
+     * </p>
      * @param dom   the root document.
      * @param xpath the xpath for the node.
      * @return the Node or null if unattainable.

--- a/fcrepo-installer/src/main/java/org/fcrepo/utilities/install/container/TomcatServerXML.java
+++ b/fcrepo-installer/src/main/java/org/fcrepo/utilities/install/container/TomcatServerXML.java
@@ -65,7 +65,7 @@ public class TomcatServerXML
     /**
      * Sets the http port and Fedora default http connector options.
      * 
-     * @see http://tomcat.apache.org/tomcat-6.0-doc/config/http.html
+     * @see "http://tomcat.apache.org/tomcat-6.0-doc/config/http.html"
      * @throws InstallationFailedException
      */
     public void setHTTPPort() throws InstallationFailedException {

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/pom.xml
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/pom.xml
@@ -50,6 +50,13 @@
     </dependency>
 
     <dependency>
+      <!-- necessary for javadoc generation -->
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexRebuilderTest.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexRebuilderTest.java
@@ -40,7 +40,7 @@ import org.fcrepo.utilities.Foxml11Document.State;
 
 /**
  * Test of the ResourceIndexRebuilder. Requires that Fedora already be installed.
- * Note that this is a long-running test because of the ingest & purge cycle.
+ * Note that this is a long-running test because of the ingest &amp; purge cycle.
  *
  * @author Edwin Shin
  * @version $Id: ResourceIndexRebuilderTest.java 7508 2008-07-15 04:00:43Z pangloss $

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/FedoraServerTestCase.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/FedoraServerTestCase.java
@@ -108,7 +108,7 @@ public abstract class FedoraServerTestCase
      * hierarchy
      * </p>
      *
-     * @param path format-independent path to a directory within the demo object
+     * @param paths format-independent path to a directory within the demo object
      *             hierarchy.
      * @throws Exception
      */

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestManagementNotifications.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestManagementNotifications.java
@@ -513,7 +513,6 @@ public class TestManagementNotifications
 
     /**
      * Handles messages sent as notifications.
-     * <p/>
      * {@inheritDoc}
      */
     @Override

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestRESTAPI.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestRESTAPI.java
@@ -2204,7 +2204,7 @@ public class TestRESTAPI
         EntityUtils.consumeQuietly(response.getEntity());
         get.releaseConnection();
         assertEquals(SC_OK, status);
-        assertEquals("19498", cLen);
+        assertEquals("19468", cLen);
     }
 
     private MultipartEntity _doUploadPost() throws Exception {

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestXACMLPolicies.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/TestXACMLPolicies.java
@@ -44,11 +44,11 @@ import org.junit.runner.JUnitCore;
 
 /**
  * Tests involving XACML policies, for API-A and API-M.
- * <p/>
+ * <p>
  * Note: Although these tests can run when API-A AuthN is off, for the best
  * coverage, make sure the server is configured to authenticate for API-A
  * access.
- *
+ * </p>
  * @author Edwin Shin
  */
 public class TestXACMLPolicies

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/ValidatorHelper.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/api/ValidatorHelper.java
@@ -35,7 +35,7 @@ public class ValidatorHelper {
      * Get all local filenames that correspond to declared schemas. Validation
      * does not work with a "union of all schemata" schema. This was an attempt
      * create the most minimal set of schema by traversing schemaLocation and
-     * <include> within the xsd files. Ultimately, this was a dead end, because
+     * &lt;include&gt; within the xsd files. Ultimately, this was a dead end, because
      * of a bug in Xerces: https://issues.apache.org/jira/browse/XERCESJ-1130
      * schemaLocation typically points to some http resource. For offline tests,
      * we want to use the local copy of that resource (since we know we have

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/fesl/util/DataUtils.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/fesl/util/DataUtils.java
@@ -47,7 +47,7 @@ public class DataUtils {
     /**
      * Creates an XML document object from a file.
      *
-     * @param file
+     * @param filename
      *        the filename of the file to load.
      * @return the XML document object.
      * @throws Exception
@@ -82,8 +82,8 @@ public class DataUtils {
     /**
      * Creates an XML document object from a byte array.
      *
-     * @param file
-     *        the file to load.
+     * @param data
+     *        the bytes to load.
      * @return the XML document object.
      * @throws Exception
      */
@@ -115,8 +115,8 @@ public class DataUtils {
     /**
      * Loads a file into a byte array.
      *
-     * @param File
-     *        to load.
+     * @param file
+     *        File to load.
      * @return byte array containing the data file.
      * @throws Exception
      */

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/integration/TestLargeDatastreams.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/integration/TestLargeDatastreams.java
@@ -40,13 +40,13 @@ import org.fcrepo.test.FedoraTestCase;
 
 
 /**
- * Performs ingest and export tests using large datastreams.
+ * <p>Performs ingest and export tests using large datastreams.
  * This test creates and moves very large files and as such
  * takes significant time to run.
- * <p/>
+ * </p><p>
  * Non-SSL transports *MUST* be available for all APIs in order
  * for this test to run properly.
- *
+ * </p>
  * @author Bill Branan
  */
 public class TestLargeDatastreams

--- a/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/integration/cma/SharedDeploymentTests.java
+++ b/fcrepo-integrationtest/fcrepo-integrationtest-core/src/main/java/org/fcrepo/test/integration/cma/SharedDeploymentTests.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  * model. Furthermore, individual methods/operations/endpoints are defined
  * within each individual service object. In order to invoke a specific method,
  * the identites of the object, the sDef, and the method need to be specified.
- * In that light, this suite tests the following:
+ * In that light, this suite tests the following:</p>
  * <ul>
  * <li>The system will enumerate (via iewItemIndex, listMethods, etc) ONLY those
  * services/methods/endpoints that are specified by the graph containing the
@@ -45,7 +45,6 @@ import org.junit.Test;
  * may make use of multiple SDeps to provide full deployment coverage of all its
  * methods.</li>
  * </ul>
- * </p>
  *
  * @author birkland
  */

--- a/fcrepo-security/fcrepo-security-jaas/src/main/java/org/fcrepo/server/security/jaas/util/Base64.java
+++ b/fcrepo-security/fcrepo-security-jaas/src/main/java/org/fcrepo/server/security/jaas/util/Base64.java
@@ -78,7 +78,7 @@ import org.fcrepo.utilities.ReadableByteArrayOutputStream;
  * projects and then had gobs of javadoc warnings on this file.</li>
  * </ul>
  * <li>v2.2.1 - Fixed bug using URL_SAFE and ORDERED encodings. Fixed bug when
- * using very small files (~< 40 bytes).</li>
+ * using very small files (~&lt; 40 bytes).</li>
  * <li>v2.2 - Added some helper methods for encoding/decoding directly from one
  * file to the next. Also added a main() method to support command line
  * encoding/decoding from one file to the next. Also added these Base64
@@ -1701,7 +1701,7 @@ public class Base64 {
          * <pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: break lines at 76 characters
-         *     (only meaningful when encoding)</i>
+         *     <i>(only meaningful when encoding)</i>
          * </pre>
          * <p>
          * Example: <code>new Base64.InputStream( in, Base64.DECODE )</code>
@@ -1922,7 +1922,7 @@ public class Base64 {
          * <pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: don't break lines at 76 characters
-         *     (only meaningful when encoding)</i>
+         *     <i>(only meaningful when encoding)</i>
          * </pre>
          * <p>
          * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>

--- a/fcrepo-security/fcrepo-security-jaas/src/main/java/org/fcrepo/server/security/jaas/util/SubjectUtils.java
+++ b/fcrepo-security/fcrepo-security-jaas/src/main/java/org/fcrepo/server/security/jaas/util/SubjectUtils.java
@@ -35,10 +35,10 @@ public class SubjectUtils {
             LoggerFactory.getLogger(SubjectUtils.class);
 
     /**
-     * Get the attribute map of String keys to Set<String> values
+     * Get the attribute map of String keys to Set&lt;String&gt; values
      * This method will not return a null
      * @param subject
-     * @return
+     * @return Map&lt;String, Set&lt;String&gt;&gt;
      */
     
     @SuppressWarnings("unchecked")

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/HierarchicalLowestChildDenyOverridesPolicyAlg.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/HierarchicalLowestChildDenyOverridesPolicyAlg.java
@@ -98,7 +98,7 @@ public class HierarchicalLowestChildDenyOverridesPolicyAlg
      *        the context from the request
      * @param parameters
      *        a (possibly empty) non-null <code>List</code> of
-     *        <code>CombinerParameter<code>s
+     *        <code>CombinerParameter</code>s
      * @param policyElements
      *        the policies to combine
      * @return the result of running the combining algorithm

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/HierarchicalLowestChildPermitOverridesPolicyAlg.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/HierarchicalLowestChildPermitOverridesPolicyAlg.java
@@ -98,7 +98,7 @@ public class HierarchicalLowestChildPermitOverridesPolicyAlg
      *        the context from the request
      * @param parameters
      *        a (possibly empty) non-null <code>List</code> of
-     *        <code>CombinerParameter<code>s
+     *        <code>CombinerParameter</code>s
      * @param policyElements
      *        the policies to combine
      * @return the result of running the combining algorithm

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/DbXmlPolicyIndex.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/DbXmlPolicyIndex.java
@@ -413,7 +413,7 @@ public class DbXmlPolicyIndex
      * @param policyName
      * @return true iff the policy store contains a policy identified as
      *         policyName
-     * @throws PolicyStoreException
+     * @throws PolicyIndexException
      */
     @Override
     public boolean contains(String policyName)

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyIndex.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyIndex.java
@@ -65,7 +65,7 @@ public interface PolicyIndex {
      * @param name
      *        the name of the policy to return
      * @return the policy as an array of bytes
-     * @throws PolicyStoreException
+     * @throws PolicyIndexException
      */
     AbstractPolicy getPolicy(String name, PolicyFinder policyFinder) throws PolicyIndexException;
 
@@ -78,7 +78,7 @@ public interface PolicyIndex {
      *        the policy as a {@link String}
      *
      * @return the name of the added policy
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyIndexException
      */
     String addPolicy(String name, String document)
             throws PolicyIndexException;
@@ -89,7 +89,7 @@ public interface PolicyIndex {
      * @param name
      *        the name of the policy
      * @return true if policy was deleted
-     * @throws PolicyStoreException
+     * @throws PolicyIndexException
      */
     boolean deletePolicy(String name) throws PolicyIndexException;
 
@@ -103,7 +103,7 @@ public interface PolicyIndex {
      * @param newDocument
      *        the new policy as a {@link String}
      * @return true if policy was updated
-     * @throws PolicyStoreException
+     * @throws PolicyIndexException
      */
     boolean updatePolicy(String name, String newDocument)
             throws PolicyIndexException;
@@ -111,16 +111,16 @@ public interface PolicyIndex {
     /**
      * Check if the policy identified by policyName exists.
      *
-     * @param policy
+     * @param policyName the PolicyId value
      * @return true iff the policy store contains a policy with the same
      *         PolicyId
-     * @throws PolicyStoreException
+     * @throws PolicyIndexException
      */
     boolean contains(String policyName) throws PolicyIndexException;
 
     /**
      * Clear the policy index completely
-     * @return
+     * @return boolean
      * @throws PolicyIndexException
      */
     boolean clear() throws PolicyIndexException;

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyStore.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyStore.java
@@ -52,7 +52,7 @@ public interface PolicyStore {
      * @param name
      *        the name to assign the policy
      * @return the name of the policy
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyStoreException
      */
     String addPolicy(File f, String name)
             throws PolicyStoreException;
@@ -65,7 +65,7 @@ public interface PolicyStore {
      * @param f
      *        the policy as a {@link File}
      * @return the name of the added policy
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyStoreException
      */
     String addPolicy(File f) throws PolicyStoreException;
 
@@ -77,7 +77,7 @@ public interface PolicyStore {
      *        the policy as a {@link String}
      * @param name
      * @return the name of the added policy
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyStoreException
      */
     String addPolicy(String document, String name)
             throws PolicyStoreException;
@@ -90,7 +90,7 @@ public interface PolicyStore {
      * @param document
      *        the policy as a {@link String}
      * @return the name of the added policy
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyStoreException
      */
     String addPolicy(String document) throws PolicyStoreException;
 

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyUtils.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/PolicyUtils.java
@@ -44,8 +44,8 @@ public class PolicyUtils {
      * Read file and return contents as a string
      *
      * @param f File to read
-     * @return
-     * @throws PolicyStoreException
+     * @return string contents of file
+     * @throws MelcoePDPException
      */
     public String fileToString(File f)
         throws MelcoePDPException {

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/XPathPolicyIndex.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/data/XPathPolicyIndex.java
@@ -114,8 +114,7 @@ public abstract class XPathPolicyIndex
     /**
      * Creates an XPath query from the attributes
      * @param attributeMap attributes from request
-     * @param r number of resource-id values
-     * @return
+     * @return String
      */
     protected static String getXpath(Map<String, Collection<AttributeBean>> attributeMap) {
         StringBuilder sb = new StringBuilder();

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/decorator/PolicyObject.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/decorator/PolicyObject.java
@@ -85,7 +85,7 @@ public class PolicyObject {
     /**
      * determines if this object represents an active FeSL policy
      *
-     * @return
+     * @return boolean
      * @throws ServerException
      */
     public boolean isPolicyActive() throws ServerException {
@@ -95,7 +95,7 @@ public class PolicyObject {
 
     /**
      * determines if this digital object is active
-     * @return
+     * @return boolean
      * @throws ServerException
      */
     public boolean isObjectActive() throws ServerException {
@@ -108,7 +108,7 @@ public class PolicyObject {
 
     /**
      * determines if the policy datastream in this object is active
-     * @return
+     * @return boolean
      * @throws ServerException
      */
     public boolean isDatastreamActive() throws ServerException {
@@ -120,7 +120,7 @@ public class PolicyObject {
 
     /**
      * determines if this object contains a policy datastream
-     * @return
+     * @return boolean
      * @throws ServerException
      */
     public boolean hasPolicyDatastream() throws ServerException {
@@ -149,7 +149,7 @@ public class PolicyObject {
 
     /**
      * get the policy datastream content
-     * @return
+     * @return InputStream
      * @throws ServerException
      */
     public InputStream getDsContent() throws ServerException {

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/PolicyManager.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/PolicyManager.java
@@ -19,7 +19,6 @@
 package org.fcrepo.server.security.xacml.pdp.finder.policy;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -81,10 +80,12 @@ public class PolicyManager {
      * from the Policy Index , match them against the evaluation context and
      * return a policy or policy set that conforms to the evaluation context.
      *
-     * @param polFinder
+     * @param policyIndex
+     *        the policy index
+     * @param combiningAlg
+     *        the policy combining algorithm
+     * @param policyFinder
      *        the policy finder
-     * @throws URISyntaxException
-     * @throws {@link PolicyStoreException}
      */
     public PolicyManager(PolicyIndex policyIndex, PolicyCombiningAlgorithm combiningAlg,
                          PolicyFinder policyFinder) {
@@ -116,7 +117,7 @@ public class PolicyManager {
      *        the Evaluation Context
      * @return the Policy/PolicySet that applies to this EvaluationCtx
      * @throws TopLevelPolicyException
-     * @throws {@link PolicyStoreException}
+     * @throws PolicyIndexException
      */
     public AbstractPolicy getPolicy(EvaluationCtx eval)
             throws TopLevelPolicyException, PolicyIndexException {

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/PolicyReader.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/PolicyReader.java
@@ -100,9 +100,6 @@ public class PolicyReader
      * Creates a <code>PolicyReader</code> that does not schema-validate
      * policies.
      *
-     * @param finder
-     *        a <code>PolicyFinder</code> that is used by policy sets, which may
-     *        be null only if no references are used
      */
     public PolicyReader() {
         this(null);

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/TopLevelPolicyException.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/pdp/finder/policy/TopLevelPolicyException.java
@@ -69,7 +69,7 @@ public class TopLevelPolicyException
     /**
      * Constructs a new <code>TopLevelPolicyException</code> with a message, but
      * no cause. The message is saved for later retrieval by the
-     * {@link java.lang#Throwable.getMessage() Throwable.getMessage()} method.
+     * {@link java.lang.Throwable#getMessage() Throwable.getMessage()} method.
      * 
      * @param status
      *        the <code>Status</code> associated with this error
@@ -85,7 +85,7 @@ public class TopLevelPolicyException
     /**
      * Constructs a new <code>TopLevelPolicyException</code> with a cause, but
      * no message. The cause is saved for later retrieval by the
-     * {@link java.lang#Throwable.getCause() Throwable.getCause()} method.
+     * {@link java.lang.Throwable#getCause() Throwable.getCause()} method.
      * 
      * @param status
      *        the <code>Status</code> associated with this error
@@ -101,8 +101,8 @@ public class TopLevelPolicyException
     /**
      * Constructs a new <code>TopLevelPolicyException</code> with a message and
      * a cause. The message and cause are saved for later retrieval by the
-     * {@link java.lang#Throwable.getMessage() Throwable.getMessage()} and
-     * {@link java.lang#Throwable.getCause() Throwable.getCause()} methods.
+     * {@link java.lang.Throwable#getMessage() Throwable.getMessage()} and
+     * {@link java.lang.Throwable#getCause() Throwable.getCause()} methods.
      * 
      * @param status
      *        the <code>Status</code> associated with this error

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/Attribute.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/Attribute.java
@@ -23,7 +23,7 @@ public class Attribute {
     /**
      * Get named config item for this attribute
      * @param optionName
-     * @return
+     * @return String option value
      */
     public String get(String optionName) {
         return options.get(optionName);
@@ -32,7 +32,7 @@ public class Attribute {
      * Add or update a config item for this attribute
      * @param optionName
      * @param optionValue
-     * @return
+     * @return String option value
      */
     public String put(String optionName, String optionValue) {
         options.put(optionName, optionValue);

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/AttributeFinderConfig.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/AttributeFinderConfig.java
@@ -30,7 +30,7 @@ public class AttributeFinderConfig {
     /**
      * Get a Designator based on the Sun XACML designator ID
      * @param designator
-     * @return
+     * @return Designator
      */
     public Designator get(int designator) {
         return designators.get(Integer.valueOf(designator));
@@ -38,14 +38,14 @@ public class AttributeFinderConfig {
     /**
      * Get a Designator based on the XACML target name (in lower case)
      * @param designatorName
-     * @return
+     * @return Designator
      */
     public Designator get(String designatorName) {
         return designators.get(getTarget(designatorName));
     }
     /**
      * Gets the designator IDs that have been configured
-     * @return
+     * @return Set&lt;Integer&gt; designator IDs
      */
     public Set<Integer> getDesignatorIds() {
         return designators.keySet();
@@ -56,7 +56,7 @@ public class AttributeFinderConfig {
      * Returns the added/updated designator
      *
      * @param designatorName
-     * @return
+     * @return Designator
      * @throws AttributeFinderException
      */
     public Designator put(String designatorName) throws AttributeFinderException {

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/Designator.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/Designator.java
@@ -21,14 +21,14 @@ public class Designator {
     /**
      * Gets an attribute by name
      * @param attributeName
-     * @return
+     * @return Attribute
      */
     public Attribute get(String attributeName) {
         return attributes.get(attributeName);
     }
     /**
      * Get all attribute names for this designator (XACML target)
-     * @return
+     * @return Set&lt;String&gt;
      */
     public Set<String> getAttributeNames() {
         return attributes.keySet();
@@ -37,7 +37,7 @@ public class Designator {
      * Add/update an attribute for this target.  Note that the attribute will have
      * no configuration (empty configuration is created).  Returns the attribued added/updated
      * @param attributeName
-     * @return
+     * @return Attribute
      */
     public Attribute put(String attributeName) {
         Attribute attr = attributes.get(attributeName);

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/PopulatePolicyDatabase.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/PopulatePolicyDatabase.java
@@ -52,7 +52,7 @@ public class PopulatePolicyDatabase {
     }
 
     /**
-     * @deprecated Use {@link AbstractPolicyStore#addDocuments(PolicyStore)} instead
+     * @deprecated Use {@link AbstractPolicyStore#addDocuments(AbstractPolicyStore)} instead
      */
     @Deprecated
     public static synchronized void addDocuments(PolicyStore policyStore)

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolver.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolver.java
@@ -30,23 +30,11 @@ public interface RelationshipResolver {
      *
      * @param subject
      * @param relationship
-     * @param object
-     * @return
+     * @return Map&lt;String, Set&lt;String&gt;&gt; relationships
      * @throws MelcoeXacmlException
      */
     public Map<String, Set<String>> getRelationships(String subject,
                                                       String relationship) throws MelcoeXacmlException;
-
-    /**
-     * Obtains a list of parents for the given pid.
-     *
-     * @param pid
-     *        object id whose parents we wish to find
-     * @return a Set containing the parents of the pid
-     * @throws PEPException
-     */
-    // FIXME: not used?
-    //public Set<String> getParents(String pid) throws MelcoeXacmlException;
 
     /**
      * Generates a REST based representation of an object and its parents. For
@@ -56,7 +44,7 @@ public interface RelationshipResolver {
      * @param pid
      *        the pid whose parents we need to find
      * @return the REST representation of the pid and its parents
-     * @throws PEPException
+     * @throws MelcoeXacmlException
      */
     public String buildRESTParentHierarchy(String pid)
             throws MelcoeXacmlException;
@@ -71,7 +59,7 @@ public interface RelationshipResolver {
      * @param query The query to run
      * @param queryLang Language of the query - itql, sparql, spo
      * @param variable - the output variable to return (for spo, specify "s", "p" or "o")
-     * @return
+     * @return Set&lt;String&gt; attributes
      * @throws MelcoeXacmlException
      */
     public Set<String> getAttributesFromQuery(String query, String queryLang, String variable) throws MelcoeXacmlException;

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolverBase.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolverBase.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.fcrepo.common.Constants;
 import org.fcrepo.common.MalformedPIDException;
 import org.fcrepo.common.PID;
-import org.fcrepo.server.security.xacml.pdp.MelcoePDPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,11 +35,10 @@ public abstract class RelationshipResolverBase
 
     /**
      * Constructor that takes a map of parent-child predicates (relationships).
-     * {@link ContextHandlerImpl} builds the map from the relationship-resolver
+     * org.fcrepo.server.security.xacml.pep.ContextHandlerImpl builds the map from the relationship-resolver
      * section of config-melcoe-pep.xml (in WEB-INF/classes).
      *
      * @param options
-     * @throws MelcoePDPException
      */
     public RelationshipResolverBase(Map<String, String> options) {
         parentRelationships = new ArrayList<String>();

--- a/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolverImpl.java
+++ b/fcrepo-security/fcrepo-security-pdp/src/main/java/org/fcrepo/server/security/xacml/util/RelationshipResolverImpl.java
@@ -23,7 +23,6 @@ import org.fcrepo.server.errors.ObjectNotInLowlevelStorageException;
 import org.fcrepo.server.errors.ServerException;
 import org.fcrepo.server.management.Management;
 import org.fcrepo.server.security.xacml.MelcoeXacmlException;
-import org.fcrepo.server.security.xacml.pdp.MelcoePDPException;
 import org.fcrepo.server.storage.types.RelationshipTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,11 +61,10 @@ public class RelationshipResolverImpl
 
     /**
      * Constructor that takes a map of parent-child predicates (relationships).
-     * {@link ContextHandlerImpl} builds the map from the relationship-resolver
+     * org.fcrepo.server.security.xacml.pep.ContextHandlerImpl builds the map from the relationship-resolver
      * section of config-melcoe-pep.xml (in WEB-INF/classes).
      *
      * @param options
-     * @throws MelcoePDPException
      */
     public RelationshipResolverImpl(Map<String, String> options) {
         relationships = new ArrayList<String>();

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/Evaluate.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/Evaluate.java
@@ -14,15 +14,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="param0" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="param0" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatch.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatch.java
@@ -16,15 +16,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="param0" type="{http://www.w3.org/2001/XMLSchema}string" maxOccurs="unbounded"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="param0" type="{http://www.w3.org/2001/XMLSchema}string" maxOccurs="unbounded"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatchFault.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatchFault.java
@@ -14,15 +14,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="evaluateBatchFault" type="{http://www.w3.org/2001/XMLSchema}anyType"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="evaluateBatchFault" type="{http://www.w3.org/2001/XMLSchema}anyType"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatchResponse.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateBatchResponse.java
@@ -14,15 +14,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="return" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="return" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateFault.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateFault.java
@@ -14,15 +14,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="evaluateFault" type="{http://www.w3.org/2001/XMLSchema}anyType"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="evaluateFault" type="{http://www.w3.org/2001/XMLSchema}anyType"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateResponse.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pdp/client/EvaluateResponse.java
@@ -14,15 +14,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="return" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="return" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/ContextHandler.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/ContextHandler.java
@@ -39,15 +39,15 @@ public interface ContextHandler {
      * Creates a new Request.
      *
      * @param subjects
-     *        a list of Map<URI, AttributeValue> containing the attributes for a
+     *        a list of Map&lt;URI, AttributeValue&gt; containing the attributes for a
      *        set of subjects.
      * @param actions
      *        the URI of the requested Action.
      * @param resources
-     *        a Map<URI, AttributeValue> containing the attributes for a
+     *        a Map&lt;URI, AttributeValue&gt; containing the attributes for a
      *        resource.
      * @param environment
-     *        Map<URI, AttributeValue> containing the attributes for the
+     *        Map&lt;URI, AttributeValue&gt; containing the attributes for the
      *        environment.
      * @return a request context for a PDP to handle.
      * @throws PEPException

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/DirectPDPClient.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/DirectPDPClient.java
@@ -45,8 +45,8 @@ public class DirectPDPClient
     /**
      * Initialises the DirectPDPClient class.
      *
-     * @param options
-     *        a Map of options for this class
+     * @param pdp
+     *        the PDP for which this is a client
      * @throws PEPException
      */
     public DirectPDPClient(MelcoePDP pdp)

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/EvaluationEngine.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/EvaluationEngine.java
@@ -29,7 +29,7 @@ public interface EvaluationEngine {
     /**
      * Evaluates an XACML request and returns an XACML response.
      * 
-     * @param request
+     * @param reqCtx
      *        an XACML request as a RequestCtx object
      * @return and XACML response as a ResponseCtx object
      * @throws PEPException

--- a/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/ws/operations/AbstractOperationHandler.java
+++ b/fcrepo-security/fcrepo-security-pep/src/main/java/org/fcrepo/server/security/xacml/pep/ws/operations/AbstractOperationHandler.java
@@ -214,7 +214,7 @@ public abstract class AbstractOperationHandler
      *
      * @param context
      *        the message context
-     * @param param
+     * @param newResponse
      *        the object to set as the return object
      * @throws SoapFault
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/Module.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/Module.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base class for Fedora server modules.
- * </p>
  * <p>
  * A <code>Module</code> is a singleton object of a Fedora <code>Server</code>
  * instance with a simple lifecycle, supported by the <code>initModule()</code>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/Server.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/Server.java
@@ -780,7 +780,6 @@ public abstract class Server
      * Generates Spring Bean definitions for Fedora Modules.
      * Server param should be unnecessary if autowired.
      * @param className
-     * @param server
      * @param params
      * @param role
      * @return
@@ -838,9 +837,8 @@ public abstract class Server
 
     /**
      *
-     * @param DatastoreConfiguration tsDC : the datastore configuration intended for the triplestore connector
+     * @param tsDC DatastoreConfiguration : the datastore configuration intended for the triplestore connector
      * @return GenericBeanDefinition for the TriplestoreConnector
-     * @throws ClassNotFoundException
      * @throws IOException
      */
     protected static GenericBeanDefinition getTriplestoreConnectorBeanDefinition(DatastoreConfiguration tsDC)
@@ -1545,7 +1543,7 @@ public abstract class Server
     
     /**
      * Gets the server configuration under a given $FEDORA_HOME/server/ directory.
-     * @param the server directory
+     * @param serverHome the server directory
      * @return the server configuration.
      */
     public static ServerConfiguration getConfig(File serverHome) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/Access.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/Access.java
@@ -35,7 +35,7 @@ public interface Access {
      * 
      * @param context
      *        The context of this request.
-     * @param PID
+     * @param pid
      *        The persistent identifier of the digital object.
      * @param sDefPID
      *        The persistent identifier of the Service Definition object.
@@ -63,7 +63,7 @@ public interface Access {
      * 
      * @param context
      *        The context of this request.
-     * @param PID
+     * @param pid
      *        The persistent identifier of the digital object
      * @param asOfDateTime
      *        The versioning datetime stamp
@@ -144,7 +144,7 @@ public interface Access {
      * 
      * @param context
      *        The context of this request.
-     * @param PID
+     * @param pid
      *        The persistent identifier of the digitla object.
      * @return An Array containing the list of timestamps indicating when
      *         changes were made to the object.

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/DescribeRepositoryServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/DescribeRepositoryServlet.java
@@ -41,14 +41,13 @@ import org.slf4j.LoggerFactory;
  * (API-A-LITE) interface using a java servlet front end. The syntax defined by
  * API-A-LITE has for getting a description of the repository has the following
  * binding:
- * <ol>
- * <li>describeRepository URL syntax:
+ * <p>describeRepository URL syntax:
  * protocol://hostname:port/fedora/describe[?xml=BOOLEAN] This syntax requests
  * information about the repository. The xml parameter determines the type of
  * output returned. If the parameter is omitted or has a value of "false", a
  * MIME-typed stream consisting of an html table is returned providing a
  * browser-savvy means of viewing the object profile. If the value specified is
- * "true", then a MIME-typed stream consisting of XML is returned.</li>
+ * "true", then a MIME-typed stream consisting of XML is returned.</p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -59,7 +58,7 @@ import org.slf4j.LoggerFactory;
  * value of "true" indicates a return type of text/xml; the absence of the xml
  * parameter or a value of "false" indicates format is to be text/html.</li>
  * </ul>
- *
+ * 
  * @author Ross Wayland
  */
 public class DescribeRepositoryServlet

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/FedoraAccessServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/FedoraAccessServlet.java
@@ -56,8 +56,8 @@ import org.slf4j.LoggerFactory;
  * GetDatastreamDissemination of the Fedora Access LITE (API-A-LITE) interface
  * using a java servlet front end. The syntax defined by API-A-LITE defines
  * three bindings for these methods:
- * <ol>
- * <li>GetDissemination URL syntax:
+ * 
+ * GetDissemination URL syntax:
  * <p>
  * protocol://hostname:port/fedora/get/PID/sDefPID/methodName[/dateTime][?
  * parmArray]
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
  * specified method of the associated service definition object. The result is
  * returned as a MIME-typed stream.
  * </p>
- * </li>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -81,9 +80,10 @@ import org.slf4j.LoggerFactory;
  * <li>dateTime - optional dateTime value indicating dissemination of a version
  * of the digital object at the specified point in time.
  * <li>parmArray - optional array of method parameters consisting of name/value
- * pairs in the form parm1=value1&parm2=value2...</li>
+ * pairs in the form parm1=value1&amp;parm2=value2...</li>
  * </ul>
- * <li>GetObjectProfile URL syntax:
+ * 
+  * GetObjectProfile URL syntax:
  * <p>
  * protocol://hostname:port/fedora/get/PID[/dateTime][?xml=BOOLEAN]
  * </p>
@@ -95,7 +95,6 @@ import org.slf4j.LoggerFactory;
  * profile. If the value specified is "true", then a MIME-typed stream
  * consisting of XML is returned.
  * </p>
- * </li>
  * <ul>
  * <li>protocol - either http or https</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -109,13 +108,14 @@ import org.slf4j.LoggerFactory;
  * value of "true" indicates a return type of text/xml; the absence of the xml
  * parameter or a value of "false" indicates format is to be text/html.</li>
  * </ul>
- * <li>GetDatastreamDissemination URL syntax:
+ * 
+ * GetDatastreamDissemination URL syntax:
  * <p>
  * protocol://hostname:port/fedora/get/PID/DSID[/dateTime]
- * </p>
+ * </p><p>
  * This syntax requests a datastream dissemination for the specified digital
  * object. It is used to return the contents of a datastream.
- * <p></li>
+ * </p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -127,7 +127,6 @@ import org.slf4j.LoggerFactory;
  * <li>dateTime - optional dateTime value indicating dissemination of a version
  * of the digital object at the specified point in time.
  * </ul>
- * </ol>
  *
  * @author Ross Wayland
  */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/GetObjectHistoryServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/GetObjectHistoryServlet.java
@@ -46,14 +46,13 @@ import org.slf4j.LoggerFactory;
  * (API-A-LITE) interface using a java servlet front end. The syntax defined by
  * API-A-LITE has for getting a description of the repository has the following
  * binding:
- * <ol>
- * <li>getObjectHistory URL syntax:
+ * <p>getObjectHistory URL syntax:
  * protocol://hostname:port/fedora/getObjectHistory/pid[?xml=BOOLEAN] This
  * syntax requests information about the repository. The xml parameter
  * determines the type of output returned. If the parameter is omitted or has a
  * value of "false", a MIME-typed stream consisting of an html table is returned
  * providing a browser-savvy means of viewing the object profile. If the value
- * specified is "true", then a MIME-typed stream consisting of XML is returned.</li>
+ * specified is "true", then a MIME-typed stream consisting of XML is returned.</p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/ListDatastreamsServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/ListDatastreamsServlet.java
@@ -48,9 +48,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Implements listDatastreams method of Fedora Access LITE (API-A-LITE)
  * interface using a java servlet front end.
- * <ol>
- * <li>ListDatastreams URL syntax:
- * <p>
+ * <p>ListDatastreams URL syntax:
  * protocol://hostname:port/fedora/listDatastreams/PID[/dateTime][?xml=BOOLEAN]
  * </p>
  * <p>
@@ -61,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * profile. If the value specified is "true", then a MIME-typed stream
  * consisting of XML is returned.
  * </p>
- * </li>
+ * 
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -76,7 +74,6 @@ import org.slf4j.LoggerFactory;
  * value of "true" indicates a return type of text/xml; the absence of the xml
  * parameter or a value of "false" indicates format is to be text/html.</li>
  * </ul>
- * </ol>
  *
  * @author Ross Wayland
  * @version $Id: ListDatastreamsServlet.java 7781 2008-10-15 20:03:30Z pangloss

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/ListMethodsServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/ListMethodsServlet.java
@@ -50,8 +50,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Implements listMethods method of Fedora Access LITE (API-A-LITE) interface
  * using a java servlet front end.
- * <ol>
- * <li>ListMethods URL syntax:
+ * ListMethods URL syntax:
  * <p>
  * protocol://hostname:port/fedora/listMethods/PID[/dateTime][?xml=BOOLEAN]
  * </p>
@@ -63,7 +62,6 @@ import org.slf4j.LoggerFactory;
  * profile. If the value specified is "true", then a MIME-typed stream
  * consisting of XML is returned.
  * </p>
- * </li>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -78,7 +76,6 @@ import org.slf4j.LoggerFactory;
  * value of "true" indicates a return type of text/xml; the absence of the xml
  * parameter or a value of "false" indicates format is to be text/html.</li>
  * </ul>
- * </ol>
  *
  * @author Ross Wayland
  * @version $Id$

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/defaultdisseminator/ServiceMethodDispatcher.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/defaultdisseminator/ServiceMethodDispatcher.java
@@ -32,7 +32,7 @@ public class ServiceMethodDispatcher {
      *        the method to invoke on the target object
      * @param userParms
      *        parameters to the method to invoke on target object
-     * @return
+     * @return Object product of the method
      * @throws ServerException
      */
     public Object invokeMethod(Object service_object,

--- a/fcrepo-server/src/main/java/org/fcrepo/server/access/dissemination/DisseminationService.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/access/dissemination/DisseminationService.java
@@ -759,7 +759,6 @@ public class DisseminationService {
 	 * The format of the tempID is derived from <code>java.sql.Timestamp</code>
 	 * with an arbitrary counter appended to the end to insure uniqueness. The
 	 * syntax is of the form:
-	 * <ul>
 	 * <p>
 	 * YYYY-MM-DD HH:mm:ss.mmm:dddddd where
 	 * </p>
@@ -772,7 +771,6 @@ public class DisseminationService {
 	 * <li>ss - seconds (0-59)</li>
 	 * <li>mmm - milliseconds (0-999)</li>
 	 * <li>dddddd - incremental counter (0-999999)</li>
-	 * </ul>
 	 * </ul>
 	 * 
 	 * @param dsLocation

--- a/fcrepo-server/src/main/java/org/fcrepo/server/errors/ServerInitializationException.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/errors/ServerInitializationException.java
@@ -6,7 +6,6 @@ package org.fcrepo.server.errors;
 
 /**
  * Signifies that an error occurred during the server's initialization.
- * </p>
  * 
  * @author Chris Wilper
  */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/journal/JournalCreator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/journal/JournalCreator.java
@@ -26,13 +26,13 @@ import javax.ws.rs.core.StreamingOutput;
 
 
 /**
- * This is the worker class to use in Journaling mode (normal mode).
- * <p/>
+ * <p>This is the worker class to use in Journaling mode (normal mode).
+ * </p><p>
  * Each time a "writing" Management method is called, create a
  * CreatorJournalEntry and ask it to invoke the method on the
  * ManagementDelegate. If a "read-only" Management method is called, just pass
  * it along to the ManagementDelegate.
- *
+ * </p>
  * @author Jim Blake
  */
 public class JournalCreator

--- a/fcrepo-server/src/main/java/org/fcrepo/server/journal/JournalWriter.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/journal/JournalWriter.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * Note that the writing of an entry is necessarily a three step process,
- * consisting of
+ * consisting of:</p>
  * <ol>
  * <li>calling {@link #prepareToWriteJournalEntry()},</li>
  * <li>invoking the management method,</li>
@@ -61,7 +61,6 @@ import org.slf4j.LoggerFactory;
  * {@link CreatorJournalEntry}, and these values must be written to the
  * journal.</li>
  * </ul>
- * </p>
  *
  * @author Jim Blake
  */
@@ -125,7 +124,7 @@ public abstract class JournalWriter
 
     /**
      * Concrete sub-classes should insure that a message transport is ready, and
-     * call {@link #writeDocumentHeader(XMLEventWriter) if needed. This method
+     * call {@link #writeDocumentHeader(XMLEventWriter)} if needed. This method
      * is called separately from {@link #writeJournalEntry(CreatorJournalEntry)},
      * so we can obtain the repository hash before the Management method is
      * invoked.
@@ -134,7 +133,7 @@ public abstract class JournalWriter
 
     /**
      * Concrete sub-classes should provide an XMLEventWriter, and call
-     * {@link #writeJournalEntry(XMLEventWriter)}, after which, they should
+     * {@link #writeJournalEntry(CreatorJournalEntry, XMLEventWriter)}, after which, they should
      * probably flush the XMLEventWriter. This method is called after the
      * Management method is invoked, since the Management method may modify the
      * context object in the journal entry.

--- a/fcrepo-server/src/main/java/org/fcrepo/server/journal/helpers/FileMovingUtil.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/journal/helpers/FileMovingUtil.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 /**
  * Provides a workaround to the fact that
- * {@link java.io.File.renameTo(java.io.File)} doesn't work across NFS file
+ * {@link java.io.File#renameTo(java.io.File)} doesn't work across NFS file
  * systems.
  * <p>
  * This code is taken from a workaround provided on the Sun Developer Network
@@ -21,11 +21,11 @@ import java.io.IOException;
  * mailto:morgan.sziraki@cartesian.co.uk
  * </p>
  * <p>
- * The code is modified to protect against a situation where
+ * The code is modified to protect against a situation where:</p>
  * <ul>
  * <li>We need to copy the file across NFS mounted filesystems</li>
  * <li>Another process is waiting for the file to be renamed</li>
- * </ul>
+ * </ul><p>
  * If we do a simple copy, we leave open the possibility that the second process
  * will see the new file created before we have a chance to copy the contents.
  * </p>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/journal/readerwriter/multicast/LocalDirectoryTransport.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/journal/readerwriter/multicast/LocalDirectoryTransport.java
@@ -24,15 +24,12 @@ import org.fcrepo.server.journal.helpers.ParameterHelper;
 
 /**
  * <p>
- * LocalDirectoryTransport.java
- * </p>
- * <p>
  * Writes Journal files to a local disk directory. It requires these parameters:
+ * </p>
  * <ul>
  * <li>directoryPath - full path to the directory where the Journals will be
  * stored.</li>
  * </ul>
- * </p>
  *
  * @author jblake
  * @version $Id: LocalDirectoryTransport.java,v 1.1 2007/03/06 15:02:58 jblake

--- a/fcrepo-server/src/main/java/org/fcrepo/server/journal/readerwriter/multicast/MulticastJournalWriter.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/journal/readerwriter/multicast/MulticastJournalWriter.java
@@ -37,7 +37,7 @@ import static org.fcrepo.server.journal.readerwriter.multicast.Transport.State.S
 
 /**
  * SYNCHRONIZATION NOTE: All public methods are synchronized against
- * {@link JournalWriter.SYNCHRONIZER}, as is the {@link #closeFile() closeFile}
+ * {@link JournalWriter#SYNCHRONIZER}, as is the {@link #closeFile() closeFile}
  * method. This means that an asynchronous call by the timer task will not
  * interrupt a synchronous operation already in progress, or vice versa.
  *

--- a/fcrepo-server/src/main/java/org/fcrepo/server/management/DBPIDGenerator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/management/DBPIDGenerator.java
@@ -50,8 +50,8 @@ public class DBPIDGenerator
      * generated PID as reported by the log files in that directory. This is to
      * support automatic upgrade of this functionality from versions of Fedora
      * prior to 1.2.
-     * @throws ModuleInitializationException 
-     * @throws  
+     * @throws IOException
+     * @throws ModuleInitializationException
      */
     public DBPIDGenerator(ConnectionPool cPool, File oldPidGenDir)
             throws IOException, ModuleInitializationException {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/management/DefaultManagement.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/management/DefaultManagement.java
@@ -120,8 +120,8 @@ public class DefaultManagement
     /**
      * @param purgeDelayInMillis milliseconds to delay before removing
      *                           old uploaded files
-     * @author Frederic Buffet & Tommy Bourdin (Atos Worldline)
-     * @date August 1, 2008
+     * @author Frederic Buffet &amp; Tommy Bourdin (Atos Worldline)
+     * @since August 1, 2008
      */
     public DefaultManagement(Authorization authz,
                              DOManager doMgr,
@@ -1978,7 +1978,6 @@ public class DefaultManagement
      * @param pid
      * @param dsID
      * @param controlGroup - new Control Group for datastream
-     * @param ignoreAlreadyDone - if true don't return an error if datastream already has desired control group
      * @param addXMLHeader - add an XML header declaring UTF-8 character encoding to datastream content
      * @param reformat - reformat the XML (in the same format as used for inline XML)
      * @param setMIMETypeCharset - add charset declaration (UTF-8) to the MIMEType, and add text/xml MIMEType if no MIMEType is set

--- a/fcrepo-server/src/main/java/org/fcrepo/server/management/GetNextPIDServlet.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/management/GetNextPIDServlet.java
@@ -38,9 +38,8 @@ import org.slf4j.LoggerFactory;
  * (API-M-LITE) interface using a java servlet front end. The syntax defined by
  * API-M-LITE for getting a list of the next available PIDs has the following
  * binding:
- * <ol>
- * <li>getNextPID URL syntax:
- * protocol://hostname:port/fedora/management/getNextPID[?numPIDs=NUMPIDS&namespace=NAMESPACE&xml=BOOLEAN]
+ * <p>getNextPID URL syntax:
+ * protocol://hostname:port/fedora/management/getNextPID[?numPIDs=NUMPIDS&amp;namespace=NAMESPACE&amp;xml=BOOLEAN]
  * This syntax requests a list of next available PIDS. The parameter numPIDs
  * determines the number of requested PIDS to generate. If omitted, numPIDs
  * defaults to 1. The namespace parameter determines the namespace to be used in
@@ -50,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * or has a value of "false", a MIME-typed stream consisting of an html table is
  * returned providing a browser-savvy means of viewing the object profile. If
  * the value specified is "true", then a MIME-typed stream consisting of XML is
- * returned.</li>
+ * returned.</p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/management/ManagementModule.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/management/ManagementModule.java
@@ -549,7 +549,7 @@ public class ManagementModule
     }
 
     /**
-     * {@inheritDoce}
+     * {@inheritDoc}
      */
     @Override
     public Date setDatastreamVersionable(Context context,
@@ -643,7 +643,6 @@ public class ManagementModule
      * @param pid
      * @param dsID
      * @param controlGroup - new Control Group for datastream
-     * @param ignoreAlreadyDone - if true don't return an error if datastream already has desired control group
      * @param addXMLHeader - add an XML header declaring UTF-8 character encoding to datastream content
      * @param reformat - reformat the XML (in the same format as used for inline XML)
      * @param setMIMETypeCharset - add charset declaration (UTF-8) to the MIMEType, and add text/xml MIMEType if no MIMEType is set

--- a/fcrepo-server/src/main/java/org/fcrepo/server/messaging/FedoraMessage.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/messaging/FedoraMessage.java
@@ -25,7 +25,7 @@ public interface FedoraMessage {
 
     /**
      * An identifier for the serialization format of the message.
-     * @return
+     * @return String
      */
     public String getFormat();
 }

--- a/fcrepo-server/src/main/java/org/fcrepo/server/messaging/JMSManager.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/messaging/JMSManager.java
@@ -246,7 +246,7 @@ public class JMSManager {
      * @param messageSelector
      *        selection criteria for filtering messages
      * @return the Message received for the given Destination
-     * @throws Exception
+     * @throws MessagingException
      */
     public Message listen(String destName, String messageSelector) throws MessagingException {
         if(logger.isDebugEnabled()) {
@@ -279,7 +279,7 @@ public class JMSManager {
      * @param messageSelector
      *        selection criteria for filtering messages
      * @return the Message received for the given Destination
-     * @throws Exception
+     * @throws MessagingException
      */
     public Message listen(Destination dest, String messageSelector) throws MessagingException {
         if(logger.isDebugEnabled()) {
@@ -319,7 +319,7 @@ public class JMSManager {
      * @param timeout
      *        time in milliseconds before timing out
      * @return the Message received for the given Destination
-     * @throws Exception
+     * @throws MessagingException
      */
     public Message listen(String destName, String messageSelector, int timeout)
             throws MessagingException {
@@ -404,7 +404,7 @@ public class JMSManager {
     }
 
     /**
-     * @see JMSManager#listenDurable(Topic, MessageListener, String)
+     * @see JMSManager#listenDurable(Topic, String, MessageListener, String)
      */
     public String listenDurable(String topicName,
                                 MessageListener callback,
@@ -421,7 +421,7 @@ public class JMSManager {
      * method is the same as calling
      * <code>listenDurable(topic, "", callback, null)</code>
      *
-     * @see JMSManager#listenDurable(Topic, MessageListener, String)
+     * @see JMSManager#listenDurable(Topic, String, MessageListener, String)
      */
     public String listenDurable(Topic topic, MessageListener callback)
             throws MessagingException {
@@ -720,7 +720,7 @@ public class JMSManager {
     /**
      * @param destName
      * @return the Session object for the specified destination name.
-     * @throws Exception
+     * @throws MessagingException
      */
     public Session getSession(String destName) throws MessagingException {
         JMSDestination jmsDest = getJMSDestination(destName);
@@ -733,7 +733,7 @@ public class JMSManager {
      * @param destName
      * @return the Destination object for the specified destination
      *         name or null if the destination does not exist
-     * @throws Exception
+     * @throws MessagingException
      */
     public Destination getDestination(String destName)
             throws MessagingException {
@@ -762,7 +762,7 @@ public class JMSManager {
     /**
      * @param destName
      * @return the MessageProducer object for the specified destination name
-     * @throws Exception
+     * @throws MessagingException
      */
     public MessageProducer getProducer(String destName)
             throws MessagingException {
@@ -773,7 +773,7 @@ public class JMSManager {
     /**
      * @param destName
      * @return the MessageConsumer object for the specified destination name
-     * @throws Exception
+     * @throws MessagingException
      */
     public MessageConsumer getConsumer(String destName)
             throws MessagingException {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/messaging/MessagingImpl.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/messaging/MessagingImpl.java
@@ -48,7 +48,7 @@ public class MessagingImpl implements Messaging {
      * </ul>
      *
      * @param fedoraBaseUrl e.g. http://localhost:8080/fedora
-     * @param mdMap a <code>Map</code> of {@link Messaging#MessageType} to
+     * @param mdMap a <code>Map</code> of {@link Messaging.MessageType} to
      * Destinations.
      * @param jndiProps the JNDI configuration properties.
      * @throws MessagingException
@@ -84,9 +84,9 @@ public class MessagingImpl implements Messaging {
 
     /**
      * Send a message to each of the destinations configured for each
-     * {@link Messaging#MessageType}. Currently, only
+     * {@link Messaging.MessageType}. Currently, only
      * {@link FedoraMethod}s that represent
-     * {@link org.fcrepo.server.Management} methods are supported.
+     * {@link org.fcrepo.server.management.Management} methods are supported.
      * {@inheritDoc}
      */
     public void send(FedoraMethod method) throws MessagingException {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/oai/FedoraOAIProviderModule.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/oai/FedoraOAIProviderModule.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An OAIProvider that acts as a server module and wraps FedoraOAIProvider.
+ * <p>An OAIProvider that acts as a server module and wraps FedoraOAIProvider.
  * </p>
  *
  * @author Chris Wilper

--- a/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndex.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndex.java
@@ -48,7 +48,7 @@ public interface ResourceIndex
     /**
      * Gets the default state of buffer synchronization. When this is
      * true, all operations are flushed on completion.
-     * @return
+     * @return boolean
      */
     boolean getSync();
     /**
@@ -92,7 +92,7 @@ public interface ResourceIndex
      * Modifying an object is the equivalent of processing the difference
      * between the export before and after a change.
      * @param object
-     * @return
+     * @return List&lt;Triple&gt;
      * @throws ResourceIndexException
      */
     List<Triple> exportObject(DOReader object) throws ResourceIndexException;

--- a/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexModule.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexModule.java
@@ -70,24 +70,24 @@ public class ResourceIndexModule
      * Perform post-initialization of this module. ResourceIndexModule takes the
      * following parameters:
      * <ul>
-     * <li> level (required, integer between 0 and 1)<br/> The level of
+     * <li> level (required, integer between 0 and 1)<br> The level of
      * indexing that should be performed. Values correspond to
      * <code>INDEX_LEVEL_OFF</code>, and <code>INDEX_LEVEL_ON</code>.
      * </li>
-     * <li> datastore (required)<br/> The name of the datastore element that
-     * contains the Trippi Connector configuration.
+     * <li> datastore (required)<br> The name of the datastore element that
+     * contains the Trippi Connector configuration.</li>
      * <li> connectionPool (optional, default is ConnectionPoolManager's
-     * default)<br/> Which connection pool to use for updating the database of
-     * method information. </li>
-     * <li> syncUpdates (optional, default is false)<br/> Whether to flush the
+     * default)<br> Which connection pool to use for updating the database of
+     * method information.</li>
+     * <li> syncUpdates (optional, default is false)<br> Whether to flush the
      * triple buffer before returning from object modification operations.
      * Specifying this as true will ensure that RI queries always reflect the
-     * latest triples. </li>
-     * <li> alias:xyz (optional, uri)<br/> Any parameter starting with "alias:"
+     * latest triples.</li>
+     * <li> alias:xyz (optional, uri)<br> Any parameter starting with "alias:"
      * will be put into Trippi's alias map, and can be used for queries. For
      * example, alias:xyz with a value of urn:example:long:uri:x:y:z: will make
      * it possible to use "xyz:a" to mean "urn:example:long:uri:x:y:z:a" in
-     * queries. </li>
+     * queries.</li>
      * </ul>
      */
     @Override

--- a/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexRebuilder.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/resourceIndex/ResourceIndexRebuilder.java
@@ -88,7 +88,6 @@ public class ResourceIndexRebuilder
     /**
      * Initialize the rebuilder, given the server configuration.
      *
-     * @returns a map of option names to plaintext descriptions.
      */
     public void setServerConfiguration(ServerConfiguration serverConfig){
         // not needed

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/CopyUtils.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/CopyUtils.java
@@ -51,12 +51,12 @@ public class CopyUtils {
     }
 
     /**
-     * Copy chars from a &ltcode&gtReader</code> to a &ltcode&gtWriter</code&gt.
+     * Copy chars from a <code>Reader</code> to a <code>Writer</code>.
      *
      * @param input
-     *            the &ltcode&gtReader</code> to read from
+     *            the <code>Reader</code> to read from
      * @param output
-     *            the &ltcode&gtWriter</code> to write to
+     *            the <code>Writer</code> to write to
      * @return the number of characters copied
      * @throws IOException
      *             In case of an I/O problem

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/DatastreamFilenameHelper.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/DatastreamFilenameHelper.java
@@ -80,8 +80,7 @@ public class DatastreamFilenameHelper {
      * in the access modules upstream.
      *
      * @param fedoraServer
-     * @param management
-     * @param access
+     * @param manager
      */
     public DatastreamFilenameHelper(Server fedoraServer, DOManager manager) {
         m_datastreamContentDispositionInlineEnabled = fedoraServer.getParameter("datastreamContentDispositionInlineEnabled");

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/DatastreamResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/DatastreamResource.java
@@ -43,12 +43,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * A rest controller to handle CRUD operations for the Fedora datastream API
+ * <p>A rest controller to handle CRUD operations for the Fedora datastream API
  * (API-M) Request syntax:
- * <p/>
+ * </p><p>
  * GET,PUT,POST,DELETE
  * prototol://hostname:port/fedora/objects/PID/datastreams/DSID/versions ?
- * [dateTime][parmArray]
+ * [dateTime][parmArray]</p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -60,8 +60,8 @@ import org.springframework.stereotype.Component;
  * <li>dateTime - optional dateTime value indicating dissemination of a version
  * of the digital object at the specified point in time.
  * <li>parmArray - optional array of method parameters consisting of name/value
- * pairs in the form parm1=value1&parm2=value2...</li>
- *
+ * pairs in the form parm1=value1&amp;parm2=value2...</li>
+ * </ul>
  * @author cuong.tran@yourmediashelf.com
  * @version $Id$
  */
@@ -76,11 +76,11 @@ public class DatastreamResource
         super(server);
     }
     /**
-     * Inquires upon all object Datastreams to obtain datastreams contained by a
+     * <p>Inquires upon all object Datastreams to obtain datastreams contained by a
      * digital object. This returns a set of datastream locations that represent
      * all possible datastreams available in the object.
-     * <p/>
-     * GET /objects/{pid}/datastreams ? asOfDateTime format
+     * </p><p>
+     * GET /objects/{pid}/datastreams ? asOfDateTime format</p>
      *
      * @param pid
      * @param dateTime
@@ -133,10 +133,10 @@ public class DatastreamResource
     }
 
     /**
-     * Invoke API-M.getDatastream(context, pid, dsID, asOfDateTime)
-     * <p/>
-     * GET /objects/{pid}/datastreams/{dsID} ? asOfDateTime &
-     * validateChecksum=true|false
+     * <p>Invoke API-M.getDatastream(context, pid, dsID, asOfDateTime)
+     * </p><p>
+     * GET /objects/{pid}/datastreams/{dsID} ? asOfDateTime &amp;
+     * validateChecksum=true|false</p>
      */
     @Path("/{dsID}")
     @GET
@@ -249,9 +249,9 @@ public class DatastreamResource
     }
 
     /**
-     * Invoke API-A.getDatastreamDissemination(context, pid, dsID, asOfDateTime)
-     * <p/>
-     * GET /objects/{pid}/datastreams/{dsID}/content ? asOfDateTime
+     * <p>Invoke API-A.getDatastreamDissemination(context, pid, dsID, asOfDateTime)
+     * </p><p>
+     * GET /objects/{pid}/datastreams/{dsID}/content ? asOfDateTime</p>
      */
     @Path("/{dsID}/content")
     @GET
@@ -286,9 +286,9 @@ public class DatastreamResource
     }
 
     /**
-     * Invoke API-M.purgeDatastream
-     * <p/>
-     * DELETE /objects/{pid}/datastreams/{dsID} ? startDT endDT logMessage
+     * <p>Invoke API-M.purgeDatastream
+     * </p><p>
+     * DELETE /objects/{pid}/datastreams/{dsID} ? startDT endDT logMessage</p>
      */
     @Path("/{dsID}")
     @DELETE
@@ -323,13 +323,13 @@ public class DatastreamResource
     }
 
     /**
-     * Modify an existing datastream.
-     * <p/>
+     * <p>Modify an existing datastream.
+     * </p><p>
      * PUT /objects/{pid}/datastreams/{dsID} ? dsLocation altIDs dsLabel
      * versionable dsState formatURI checksumType checksum logMessage
-     * <p/>
+     * </p><p>
      * Successful Response: Status: 200 OK Content-Type: text/xml Body: XML
-     * datastream profile
+     * datastream profile</p>
      */
     @Path("/{dsID}")
     @PUT
@@ -369,13 +369,14 @@ public class DatastreamResource
     }
 
     /**
-     * Add or modify a datastream.
-     * <p/>
+     * <p>Add or modify a datastream.
+     * </p><p>
      * POST /objects/{pid}/datastreams/{dsID} ? controlGroup dsLocation altIDs
      * dsLabel versionable dsState formatURI checksumType checksum logMessage
-     * <p/>
+     * </p><p>
      * Successful Response: Status: 201 Created Location: Datastream profile URL
      * Content-Type: text/xml Body: XML datastream profile
+     * </p>
      */
     @Path("/{dsID}")
     @POST

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/DescribeRepositoryResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/DescribeRepositoryResource.java
@@ -38,14 +38,13 @@ import org.springframework.stereotype.Component;
  * (API-A-LITE) interface using a java servlet front end. The syntax defined by
  * API-A-LITE has for getting a description of the repository has the following
  * binding:
- * <ol>
- * <li>describeRepository URL syntax:
+ * <p>describeRepository URL syntax:
  * protocol://hostname:port/fedora/describe[?xml=BOOLEAN] This syntax requests
  * information about the repository. The xml parameter determines the type of
  * output returned. If the parameter is omitted or has a value of "false", a
  * MIME-typed stream consisting of an html table is returned providing a
  * browser-savvy means of viewing the object profile. If the value specified is
- * "true", then a MIME-typed stream consisting of XML is returned.</li>
+ * "true", then a MIME-typed stream consisting of XML is returned.</p>
  * <ul>
  * <li>protocol - either http or https.</li>
  * <li>hostname - required hostname of the Fedora server.</li>
@@ -90,10 +89,8 @@ public class DescribeRepositoryResource
      * parameters and then execute the specified request.
      * </p>
      *
-     * @param request
-     *        The servlet request.
-     * @param response
-     *        servlet The servlet response.
+     * @param xml
+     *        whether the request is for xml or html.
      * @throws ServletException
      *         If an error occurs that effects the servlet's basic operation.
      * @throws IOException
@@ -173,8 +170,6 @@ public class DescribeRepositoryResource
          *
          * @param repositoryInfo
          *        A repository info data structure.
-         * @param pw
-         *        A PipedWriter to which the serialization info is written.
          */
         public ReposInfoSerializer(Context context,
                                    RepositoryInfo repositoryInfo) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/FedoraObjectsResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/FedoraObjectsResource.java
@@ -137,9 +137,9 @@ public class FedoraObjectsResource extends BaseRestResource {
      * (API-M-LITE) interface using a java servlet front end. The syntax defined
      * by API-M-LITE for getting a list of the next available PIDs has the
      * following binding:
-     * <ol>
+     * <ul>
      * <li>getNextPID URL syntax:
-     * protocol://hostname:port/fedora/objects/nextPID[?numPIDs=NUMPIDS&namespace=NAMESPACE&format=html,xml]
+     * protocol://hostname:port/fedora/objects/nextPID[?numPIDs=NUMPIDS&amp;namespace=NAMESPACE&amp;format=html,xml]
      * This syntax requests a list of next available PIDS. The parameter numPIDs
      * determines the number of requested PIDS to generate. If omitted, numPIDs
      * defaults to 1. The namespace parameter determines the namespace to be
@@ -150,6 +150,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      * stream consisting of an html table is returned providing a browser-savvy
      * means of viewing the object profile. If the value specified is "true",
      * then a MIME-typed stream consisting of XML is returned.</li>
+     * </ul>
      */
     @Path("/nextPID")
     @POST
@@ -238,7 +239,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      * ("info:fedora/fedora-system:FOXML-1.1" or
      * "info:fedora/fedora-system:METSFedoraExt-1.1"), and encoded appropriately
      * for the specified export context ("public", "migrate", or "archive").
-     * <p/>
+     * <br>
      * GET /objects/{pid}/export ? format context encoding
      */
     @Path(VALID_PID_PART + "/export")
@@ -278,7 +279,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      * disseminator was created or modified in the object. These timestamps can
      * be used to request a timestamped dissemination request to view the object
      * as it appeared at a specific point in time.
-     * <p/>
+     * <br>
      * GET /objects/{pid}/versions ? format
      */
     @Path(VALID_PID_PART + "/versions")
@@ -318,7 +319,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      * Gets a profile of the object which includes key metadata fields and URLs
      * for the object Dissemination Index and the object Item Index. Can be
      * thought of as a default view of the object.
-     * <p/>
+     * <br>
      * GET /objects/{pid}/objectXML
      */
     @Path(VALID_PID_PART + "/objectXML")
@@ -345,7 +346,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      * Gets a profile of the object which includes key metadata fields and URLs
      * for the object Dissemination Index and the object Item Index. Can be
      * thought of as a default view of the object.
-     * <p/>
+     * <br>
      * GET /objects/{pid} ? format asOfDateTime
      */
     @GET
@@ -388,7 +389,7 @@ public class FedoraObjectsResource extends BaseRestResource {
 
     /**
      * Permanently removes an object from the repository.
-     * <p/>
+     * <br>
      * DELETE /objects/{pid} ? logMessage
      */
     @DELETE
@@ -444,7 +445,7 @@ public class FedoraObjectsResource extends BaseRestResource {
     /**
      * Create/Update a new digital object. If no xml given in the body, will
      * create an empty object.
-     * <p/>
+     * <br>
      * POST /objects/{pid} ? label logMessage format encoding namespace ownerId state
      */
     @POST
@@ -550,7 +551,7 @@ public class FedoraObjectsResource extends BaseRestResource {
      *                         HTTP 409 Conflict if lastModifiedDate is earlier than the object's
      *                         lastModifiedDate.
      * @return The timestamp for this modification (as an XSD dateTime string)
-     * @see org.fcrepo.server.management.Management#modifyObject(org.fcrepo.server.Context, String, String, String, String, String)
+     * @see org.fcrepo.server.management.Management#modifyObject(org.fcrepo.server.Context, String, String, String, String, String, Date)
      */
     @PUT
     @Path(VALID_PID_PART)

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/RelationshipResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/RelationshipResource.java
@@ -112,9 +112,9 @@ public class RelationshipResource extends BaseRestResource {
 
     /**
      * Add a relationship.
-     * <p/>
+     * <br>
      * POST /objects/{pid}/relationships/new ? subject predicate object isLiteral datatype
-     * <p/>
+     * <br>
      * Successful Response:
      * Status: 200 OK
      */
@@ -151,9 +151,9 @@ public class RelationshipResource extends BaseRestResource {
 
     /**
      * Delete a relationship.
-     * <p/>
+     * <br>
      * DELETE /objects/{pid}/relationships ? subject predicate object isLiteral datatype
-     * <p/>
+     * <br>
      * Successful Response:
      * Status: 200 OK
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/RestHelper.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/RestHelper.java
@@ -29,6 +29,7 @@ public class RestHelper {
      * @param args
      * @return the first argument that is not null.
      */
+    @SafeVarargs
     static <T> T firstNotNull(T... args) {
         for (T arg : args) {
             if (arg != null) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/rest/param/AbstractParam.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/rest/param/AbstractParam.java
@@ -19,7 +19,7 @@ import javax.ws.rs.core.Response.Status;
  * @author Coda Hale
  * @author Edwin Shin
  * @version $Id$
- * @see http://codahale.com/what-makes-jersey-interesting-parameter-classes/
+ * @see "http://codahale.com/what-makes-jersey-interesting-parameter-classes/"
  */
 public abstract class AbstractParam<V> {
 

--- a/fcrepo-server/src/main/java/org/fcrepo/server/search/Condition.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/search/Condition.java
@@ -43,7 +43,7 @@ public class Condition {
     }
 
     /**
-     * Gets a List of Conditions from a string like: a=x b~'that\'s' c>='z'
+     * Gets a List of Conditions from a string like: a=x b~'that\'s' c&gt;='z'
      * 
      * @param query
      *        The query string.

--- a/fcrepo-server/src/main/java/org/fcrepo/server/search/FieldSearch.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/search/FieldSearch.java
@@ -15,12 +15,12 @@ import org.fcrepo.server.storage.DOReader;
  * <p>Key object metadata and dublin core fields are searchable from via
  * implementations of this interface.
  * 
- * <p>Key fields include:<dir> <i>pid, label, state, ownerId, cDate,
- * mDate, dcmDate</i></dir>
+ * <p>Key fields include: <i>pid, label, state, ownerId, cDate,
+ * mDate, dcmDate</i></p>
  * 
- * <p>Dublin core fields include:<dir> <i>title, creator, subject, description,
+ * <p>Dublin core fields include: <i>title, creator, subject, description,
  * publisher, contributor, date, format, identifier, source, language,
- * relation, coverage, rights</i></dir>
+ * relation, coverage, rights</i></p>
  * 
  * @author Chris Wilper
  */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/search/FieldSearchResultSQLImpl.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/search/FieldSearchResultSQLImpl.java
@@ -90,12 +90,12 @@ public class FieldSearchResultSQLImpl
 
     /**
      * Construct a FieldSearchResultSQLImpl object.
-     * <p />
+     * <p>
      * Upon construction, a connection is obtained from the connectionPool, and
      * the query is executed. (The connection will be returned to the pool only
      * after the last result has been obtained from the ResultSet, the session
      * is expired, or some non-recoverable error has occurred)
-     * <p />
+     * </p>
      * Once the ResultSet is obtained, one result is requested of it (and
      * remembered for use in step()); then the call returns.
      *

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/Attribute.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/Attribute.java
@@ -42,7 +42,7 @@ public interface Attribute {
 
     /**
      * Return all the values
-     * @return
+     * @return List&lt;AttributeValue&gt;
      */
     public List<AttributeValue> getValues();
 

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/DefaultAuthorization.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/DefaultAuthorization.java
@@ -25,21 +25,20 @@ import org.slf4j.LoggerFactory;
 /**
  * The Authorization module, protecting access to Fedora's API-A and API-M
  * endpoints.
- * <p/>
+ * <p>
  * The following attributes are available for use in authorization policies
  * during any enforce call.
  * </p>
  * <p>
- * subject attributes
+ * subject attributes</p>
  * <ul>
  * <li>urn:fedora:names:fedora:2.1:subject:loginId (available only if user
  * has authenticated)</li>
  * <li>urn:fedora:names:fedora:2.1:subject:<i>x</i> (available if
  * authenticated user has attribute <i>x</i>)</li>
  * </ul>
- * </p>
  * <p>
- * environment attributes derived from HTTP request
+ * environment attributes derived from HTTP request</p>
  * <ul>
  * <li>urn:fedora:names:fedora:2.1:environment:httpRequest:security
  * <ul>
@@ -62,9 +61,8 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * </li>
  * </ul>
- * </p>
  * <p>
- * environment attributes directly from HTTP request
+ * environment attributes directly from HTTP request</p>
  * <ul>
  * <li>urn:fedora:names:fedora:2.1:environment:httpRequest:authType</li>
  * <li>urn:fedora:names:fedora:2.1:environment:httpRequest:clientFqdn</li>
@@ -80,15 +78,13 @@ import org.slf4j.LoggerFactory;
  * <li>urn:fedora:names:fedora:2.1:environment:httpRequest:sessionEncoding</li>
  * <li>urn:fedora:names:fedora:2.1:environment:httpRequest:sessionStatus</li>
  * </ul>
- * </p>
  * <p>
- * other environment attributes
+ * other environment attributes</p>
  * <ul>
  * <li>urn:fedora:names:fedora:2.1:currentDateTime</li>
  * <li>urn:fedora:names:fedora:2.1:currentDate</li>
  * <li>urn:fedora:names:fedora:2.1:currentTime</li>
  * </ul>
- * </p>
  *
  * @see <a
  *      href="http://java.sun.com/products/servlet/2.2/javadoc/javax/servlet/http/HttpServletRequest.html">HttpServletRequest
@@ -176,24 +172,23 @@ public class DefaultAuthorization
      * during a call to this method.
      * </p>
      * <p>
-     * action attributes
+     * action attributes</p>
      * <ul>
      * <li>urn:fedora:names:fedora:2.1:action:id ==
      * urn:fedora:names:fedora:2.1:action:id-addDatastream</li>
      * <li>urn:fedora:names:fedora:2.1:action:api ==
      * urn:fedora:names:fedora:2.1:action:api-m</li>
      * </ul>
-     * </p>
+     * 
      * <p>
-     * resource attributes of object to which datastream would be added
+     * resource attributes of object to which datastream would be added</p>
      * <ul>
      * <li>urn:fedora:names:fedora:2.1:resource:object:pid</li>
      * <li>urn:fedora:names:fedora:2.1:resource:object:namespace (if pid is
      * "x:y", namespace is "x")</li>
      * </ul>
-     * </p>
      * <p>
-     * resource attributes of datastream which would be added
+     * resource attributes of datastream which would be added</p>
      * <ul>
      * <li>urn:fedora:names:fedora:2.1:resource:datastream:mimeType</li>
      * <li>urn:fedora:names:fedora:2.1:resource:datastream:formatUri</li>
@@ -205,7 +200,6 @@ public class DefaultAuthorization
      * <li>urn:fedora:names:fedora:2.1:resource:datastream:checksumType</li>
      * <li>urn:fedora:names:fedora:2.1:resource:datastream:checksum</li>
      * </ul>
-     * </p>
      */
     @Override
     public final void enforceAddDatastream(Context context,

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/PDPConfigurationFactory.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/PDPConfigurationFactory.java
@@ -77,7 +77,7 @@ public class PDPConfigurationFactory {
     /**
      *
      * @param algorithms accepts a Set of CombiningAlgorithm impls
-     * @return
+     * @return CombiningAlgFactory
      */
  
     public CombiningAlgFactory useAlgorithms(Set<CombiningAlgorithm> algorithms) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/PolicyParser.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/PolicyParser.java
@@ -99,7 +99,7 @@ public class PolicyParser {
      *
      * @param policyStream
      *          the serialized XACML policy
-     * @param validate
+     * @param schemaValidate
      *          whether to schema validate
      * @return the parsed policy.
      * @throws ValidationException

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/AbstractAttribute.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/AbstractAttribute.java
@@ -72,7 +72,6 @@ public abstract class AbstractAttribute implements Attribute {
     * @param issuer the attribute's issuer or null if there is none
     * @param issueInstant the moment when the attribute was issued, or null
     *                     if it's unspecified
-    * @param value the actual value associated with the attribute meta-data
     */
    public AbstractAttribute(URI id, String issuer, DateTimeAttribute issueInstant) 
    {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/BasicAttribute.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/BasicAttribute.java
@@ -97,7 +97,7 @@ public class BasicAttribute extends AbstractAttribute {
     * Creates a new <code>BasicAttribute</code>
     *
     * @deprecated As of version 1.1, replaced by
-    *        {@link #Attribute(URI,String,DateTimeAttribute,AttributeValue)}.
+    *        {see org.fcrepo.server.security.impl.AbstractAttribute(URI,String,DateTimeAttribute,AttributeValue)}.
     *             This constructor has some ambiguity in that it allows a
     *             specified datatype and a value that already has some
     *             associated datatype. The new constructor clarifies this

--- a/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/BasicRequestCtx.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/security/impl/BasicRequestCtx.java
@@ -42,7 +42,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -210,7 +209,6 @@ public class BasicRequestCtx implements RequestCtx
      *
      * @return a new <code>RequestCtx</code> constructed by parsing
      *
-     * @throws URISyntaxException if there is a badly formed URI
      * @throws ParsingException if the DOM node is invalid
      */
     public static RequestCtx getInstance(Node root) throws ParsingException {
@@ -311,7 +309,7 @@ public class BasicRequestCtx implements RequestCtx
      *
      * @return a new <code>RequestCtx</code>
      *
-     * @throws ParserException if there is an error parsing the input
+     * @throws ParsingException if there is an error parsing the input
      */
     public static RequestCtx getInstance(InputStream input)
         throws ParsingException

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/DefaultDOManager.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/DefaultDOManager.java
@@ -1018,14 +1018,14 @@ implements DOManager {
                 // of it in the digital object registry
                 registerObject(obj);
                 return w;
-            } catch (IOException e) {
+            } catch (IOException ioe) {
 
                 if (w != null) {
                     releaseWriteLock(obj.getPid());
                 }
 
                 throw new GeneralException("Error reading/writing temporary "
-                        + "ingest file", e);
+                        + "ingest file", ioe);
             } catch (Exception e) {
 
                 if (w != null) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/DefaultExternalContentManager.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/DefaultExternalContentManager.java
@@ -431,7 +431,7 @@ public class DefaultExternalContentManager
      * Last-Modified
      * ETag
      * @param String canonicalPath: the canonical path to a file system resource
-     * @param long lastModified: the date of last modification
+     * @param lastModified lastModified: the date of last modification
      * @return
      */
     private static Property[] getFileDatastreamHeaders(String canonicalPath, long lastModified) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/ExternalContentManager.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/ExternalContentManager.java
@@ -22,10 +22,8 @@ public interface ExternalContentManager {
      * result as a MIMETypedStream. Used as a wrapper with a default MIME type 
      * of "text/plain"
      * 
-     * @param url
-     *        The URL of the external content.
-     * @param context
-     *           The context map.       
+     * @param params
+     *           The context params.       
      * @return A MIME-typed stream.
      * @throws ServerException
      *         If the URL connection could not be established.

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/GSearchDOManager.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/GSearchDOManager.java
@@ -39,18 +39,18 @@ import org.fcrepo.server.storage.types.DigitalObject;
  * </p>
  * <p>
  * Required:
+ * </p>
  * <ul>
  * <li> &lt;param name="gSearchRESTURL"
  * value="http://localhost:8080/fedoragsearch/rest"/&gt;</li>
  * </ul>
- * </p>
  * <p>
  * Optional (only needed if basic auth is required for GSearch REST access):
+ * </p>
  * <ul>
  * <li> &lt;param name="gSearchUsername" value="exampleUsername"/&gt;</li>
  * <li> &lt;param name="gSearchPassword" value="examplePassword"/&gt;</li>
  * </ul>
- * </p>
  *
  * @author Chris Wilper
  */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/SimpleDOReader.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/SimpleDOReader.java
@@ -394,9 +394,6 @@ public class SimpleDOReader
         return modDates.toArray(EMPTY_STRING_ARRAY);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     private MethodDef[] listMethods(String sDefPID,
                                     ServiceDefinitionReader sDefReader,
                                     Date versDateTime)

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/SimpleDOWriter.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/SimpleDOWriter.java
@@ -147,7 +147,7 @@ public class SimpleDOWriter
     /**
      * Removes the entire digital object.
      *
-     * @throws ServerException
+     * @throws ObjectIntegrityException
      *         If any type of error occurred fulfilling the request.
      */
     public void remove() throws ObjectIntegrityException {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/ILowlevelStorage.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/ILowlevelStorage.java
@@ -35,7 +35,7 @@ public interface ILowlevelStorage {
      *
      * @param objectKey the pid of the object.
      * @param content the serialized object.
-     * @param objectStorageHints a map of hints for object storage
+     * @param objectHints a map of hints for object storage
      * @throws LowlevelStorageException if the object does not already exist
      *         or cannot be replaced for any other reason.
      */
@@ -108,7 +108,7 @@ public interface ILowlevelStorage {
      * @param content the content.
      * @throws LowlevelStorageException if the datastream version already
      *         exists or cannot be added for any other reason.
-     * @returns size - the size of the added object in bytes
+     * @return size - the size of the added object in bytes
      */
     public long addDatastream(String dsKey, InputStream content, Map<String, String> dsStorageHints)
             throws LowlevelStorageException;
@@ -121,7 +121,7 @@ public interface ILowlevelStorage {
      * @param content the content.
      * @throws LowlevelStorageException if the datastream version does not
      *         already exist or cannot be replaced for any other reason.
-     * @returns size - the size of the added object in bytes
+     * @return size - the size of the added object in bytes
      */
     public long replaceDatastream(String dsKey, InputStream content, Map<String, String> dsHints)
             throws LowlevelStorageException;

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/ISizable.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/ISizable.java
@@ -14,7 +14,7 @@ public interface ISizable {
     /**
      * Return the size of a datastream in bytes
      * @param dsKey
-     * @return
+     * @return long size of datastream contents
      * @throws LowlevelStorageException
      */
     public long getDatastreamSize(String dsKey) throws LowlevelStorageException;

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/AkubraLowlevelStorage.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/AkubraLowlevelStorage.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Akubra-backed implementation of ILowlevelStorage.
  * <p>
  * This implementation uses two Akubra <code>BlobStore</code>s; one for
- * objects and another for datastreams.
+ * objects and another for datastreams.</p>
  *
  * @author Chris Wilper
  */
@@ -63,18 +63,18 @@ public class AkubraLowlevelStorage
     /**
      * Creates an instance using the given blob stores.
      * <p>
-     * The blob stores <b>MUST</b>:
+     * The blob stores <b>MUST</b>:</p>
      * <ul>
      *   <li> be <i>non-transactional</i></li>
      *   <li> be able to accept <code>info:fedora/</code> URIs as blob ids.
      * </ul>
      * <p>
-     * The blob stores <b>MAY</b>:
+     * The blob stores <b>MAY</b>:</p>
      * <ul>
      *   <li> support atomic overwrites natively. If not,
      *        <code>forceSafe..Overwrites</code> MUST be given as
      *        <code>true</code> and the blob store MUST support
-     *        {@link org.akubraproject.core.Blob#renameTo}
+     *        {@link org.akubraproject.Blob#moveTo}
      *   </li>
      * </ul>
      *

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/AkubraLowlevelStorageModule.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/AkubraLowlevelStorageModule.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Required;
 
 
 /**
- * Wraps a Spring-configured {@link AkubraLowlevelStore} instance as a
+ * Wraps a Spring-configured {@link AkubraLowlevelStorage} instance as a
  * {@link Module}.
  * <p>
  * To use this module, edit <code>$FEDORA_HOME/config/akubra-llstore.xml</code>
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Required;
  * <p>
  * <pre>
  * &lt;module role="org.fcrepo.server.storage.lowlevel.ILowlevelStorage"
- *   class="org.fcrepo.server.storage.lowlevel.akubra.AkubraLowlevelStorageModule"/>
+ *   class="org.fcrepo.server.storage.lowlevel.akubra.AkubraLowlevelStorageModule"/&gt;
  * </pre>
  *
  * @author Chris Wilper

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/HashPathIdMapper.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/lowlevel/akubra/HashPathIdMapper.java
@@ -76,7 +76,7 @@ public class HashPathIdMapper
     /**
      * Creates an instance that will use the given pattern.
      *
-     * @param pathPattern the pattern to use, possibly <code>null</code> or "".
+     * @param pattern the pattern to use, possibly <code>null</code> or "".
      * @throws IllegalArgumentException if the pattern is invalid.
      */
     public HashPathIdMapper(String pattern) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/service/ServiceMapper.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/service/ServiceMapper.java
@@ -26,7 +26,6 @@ import org.xml.sax.helpers.DefaultHandler;
  * found in service objects. The intent of this class is to initiate parsing of
  * these datastreams so that information about a service can be
  * instantiated in Fedora.
- * </p>
  * 
  * @author Sandy Payette
  * @version $Id$

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/AtomDODeserializer.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/AtomDODeserializer.java
@@ -597,10 +597,11 @@ public class AtomDODeserializer
     }
 
     /**
-     * Returns the an Entry's contentSrc as a File relative to {@link #m_tempDir}.
+     * Returns the an Entry's contentSrc as a File relative to the tempDir param.
      *
      * @param contentSrc
-     * @return the contentSrc as a File relative to m_tempDir.
+     * @param tempDir
+     * @return the contentSrc as a File relative to tempDir.
      * @throws ObjectIntegrityException
      */
     protected File getContentSrcAsFile(IRI contentSrc, File tempDir) throws ObjectIntegrityException, IOException {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/AtomDOSerializer.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/AtomDOSerializer.java
@@ -47,12 +47,12 @@ import org.fcrepo.utilities.ReadableCharArrayWriter;
  * represented via the Atom Threading Extensions.
  * For convenience, a datastream entry references its latest datastream
  * version entry with an atom:link element. For example, a DC datastream
- * entry with a reference to its most recent version: <br/>
- * <code>&lt;link href="info:fedora/demo:foo/DC/2008-04-01T12:30:15.123" rel="alternate"/&gt</code></p>
+ * entry with a reference to its most recent version: <br>
+ * <code>&lt;link href="info:fedora/demo:foo/DC/2008-04-01T12:30:15.123" rel="alternate"/&gt;</code></p>
  *
  * <p>Each datastream version refers to its parent datastream via a
  * thr:in-reply-to element. For example, the entry for a DC datastream
- * version would include:<br/>
+ * version would include:<br>
  * <code>&lt;thr:in-reply-to ref="info:fedora/demo:foo/DC"/&gt;</code></p>
  *
  * @see <a href="http://atomenabled.org/developers/syndication/atom-format-spec.php">The Atom Syndication Format</a>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/ConvertObjectSerialization.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/ConvertObjectSerialization.java
@@ -122,7 +122,7 @@ public class ConvertObjectSerialization {
      *
      * @param source
      * @param destination
-     * @return
+     * @return boolean
      */
     public boolean convert(File source, File destination) {
         boolean result = true;

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/DOTranslationUtility.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/DOTranslationUtility.java
@@ -66,10 +66,10 @@ import org.slf4j.LoggerFactory;
  * usage 1=Serialize java object to XML appropriate for "public" export
  * (absolute URLs) 2=Serialize java object to XML appropriate for move/migrate
  * to another repository 3=Serialize java object to XML appropriate for internal
- * storage</b> </p> The public "normalize*" methods in this class should be
+ * storage<p> The public "normalize*" methods in this class should be
  * called to make the right decisions about what conversions should occur for
  * what contexts. Other utility methods set default values for datastreams and
- * disseminators.
+ * disseminators.</p>
  *
  * @author Sandy Payette
  * @version $Id$
@@ -360,7 +360,7 @@ public abstract class DOTranslationUtility
      * "http://myrepo.com:8080/fedora/get/demo:1/sdef:1/getFoo?in="
      * http://myrepo.com:8080/fedora/get/demo:2/DC"
      *
-     * @param m_xmlContent
+     * @param input
      * @return String with all relative repository URLs and Fedora local URLs
      *         converted to absolute URL syntax.
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/DOTranslator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/translation/DOTranslator.java
@@ -6,7 +6,6 @@ package org.fcrepo.server.storage.translation;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 
 import org.fcrepo.server.errors.ObjectIntegrityException;
 import org.fcrepo.server.errors.ServerException;
@@ -42,7 +41,7 @@ public interface DOTranslator {
      *         if there is an error reading from the stream.
      * @throws ServerException
      *         if the translator is unable to deserialize for any other reason.
-     * @throws UnsupportedEncodingException
+     * @throws UnsupportedTranslationException
      *         if the encoding is not supported by the JVM.
      * @see DOTranslationUtility#DESERIALIZE_INSTANCE
      */
@@ -71,7 +70,7 @@ public interface DOTranslator {
      *         if there is an error writing to the stream.
      * @throws ServerException
      *         if the translator is unable to serialize for any other reason.
-     * @throws UnsupportedEncodingException
+     * @throws UnsupportedTranslationException
      *         if the encoding is not supported by the JVM.
      * @see DOTranslationUtility#SERIALIZE_EXPORT_ARCHIVE
      * @see DOTranslationUtility#SERIALIZE_EXPORT_PUBLIC

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/Datastream.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/Datastream.java
@@ -155,7 +155,7 @@ public class Datastream {
     /**
      * Calculate and return the size of the data if possible
      * @param ctx
-     * @return
+     * @return long content size
      * @throws StreamIOException
      */
     public long getContentSize(Context ctx) throws StreamIOException {
@@ -341,7 +341,7 @@ public class Datastream {
 
     /**
      * true if the datastream is managed content or inline XML
-     * @return
+     * @return boolean
      */
     public boolean isRepositoryManaged() {
         return "M".equalsIgnoreCase(DSControlGrp) || "X".equalsIgnoreCase(DSControlGrp);

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/DatastreamManagedContent.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/DatastreamManagedContent.java
@@ -193,7 +193,7 @@ public class DatastreamManagedContent
      * Return the size of the data if possible
      * (IE, it is a file or LLStore implements ISizable)
      * @param ctx
-     * @return
+     * @return long content size
      * @throws StreamIOException
      */
     @Override

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/DigitalObject.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/DigitalObject.java
@@ -79,8 +79,8 @@ public interface DigitalObject {
     /**
      * Sets the owner of the object.
      *
-     * @param user
-     *        The userid.
+     * @param owner
+     *        The userid of the owner.
      */
     public void setOwnerId(String owner);
 

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/MIMETypedStream.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/MIMETypedStream.java
@@ -163,7 +163,7 @@ public class MIMETypedStream {
     /**
      * Typically 200, but control group R datastream content responses will use
      * 302, and conditional GET of datastream contents may return a 304
-     * @return
+     * @return int status code to use for the response
      */
     public int getStatusCode() {
         return m_httpStatus;

--- a/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/XMLDatastreamProcessor.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/storage/types/XMLDatastreamProcessor.java
@@ -158,7 +158,7 @@ public class XMLDatastreamProcessor {
 
     /**
      * Get the XML content of the datastream wrapped by this class
-     * @return
+     * @return byte[] contents
      */
     public byte [] getXMLContent() {
         return getXMLContent(null);
@@ -186,7 +186,7 @@ public class XMLDatastreamProcessor {
 
     /**
      * Get the datastream wrapped by this class
-     * @return
+     * @return Datastream
      */
     public Datastream getDatastream() {
         return m_ds;
@@ -229,7 +229,7 @@ public class XMLDatastreamProcessor {
     }
     /**
      * Get the DSMDClass of the datastream wrapped by this class
-     * @return
+     * @return int
      */
     public int getDSMDClass() {
         if (m_dsType == DS_TYPE.INLINE_XML)

--- a/fcrepo-server/src/main/java/org/fcrepo/server/upload/UploadResource.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/upload/UploadResource.java
@@ -43,7 +43,7 @@ public class UploadResource extends BaseRestResource {
     /**
      * Uploads a file encoded in a multipart/form message.
      *
-     * @param multiPart
+     * @param multipart
      *            the multiPart object containing the file to be uploaded
      * @return a URI with the (custom) uploaded:// scheme and a unique
      *         identifier to be used future ingests. Returns 202 if request succeeds

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/CleanupContextListener.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/CleanupContextListener.java
@@ -52,7 +52,7 @@ public class CleanupContextListener implements ServletContextListener {
     /**
      * Clean up resources used by the application when stopped
      *
-     * @seejavax.servlet.ServletContextListener#contextDestroyed(javax.servlet
+     * @see javax.servlet.ServletContextListener#contextDestroyed(javax.servlet
      * .ServletContextEvent)
      */
     @Override

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/DCFields.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/DCFields.java
@@ -281,7 +281,7 @@ public class DCFields
     /**
      * Ensure the dc:identifiers include the pid of the target object
             * @param targetPid
-            * @return
+            * @return String xml
      */
     public String getAsXML(String targetPid) {
         ReadableCharArrayWriter out = new ReadableCharArrayWriter(512);

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/PIDStreamIterableWrapper.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/PIDStreamIterableWrapper.java
@@ -18,12 +18,13 @@ import java.util.NoSuchElementException;
  * Allows a stream containing a list of pids to be iterated in a for (String pid : wrapper) statement.
  *
  * Stream must contain either:
+ * <ul>
  * <li>Raw list of PIDs, separated by newlines (blank lines are skipped)</li>
  * <li>XML containing &lt;pid&gt; elements.  Structure of XML is not interpreted,
  * only single lines containing this element are read.  Only one PID per line.
  * Empty pid elements (&lt;pid/&gt;) will be skipped.
  * This is compatible with basic search output</li>
- *
+ * </ul>
  * @author Stephen Bayliss
  * @version $Id$
  */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/StringUtility.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/StringUtility.java
@@ -120,8 +120,6 @@ public class StringUtility {
      *        The maximum length of each line (not counting the indent spaces).
      * @param writer
      *        The character stream to print the output to.
-     * @return A string split into multiple indented lines whose length is less
-     *         than the specified length + indent amount.
      */
     public static void splitAndIndent(String str, int indent,
             int numChars, PrintWriter writer) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/rebuild/Rebuilder.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/rebuild/Rebuilder.java
@@ -30,7 +30,6 @@ public interface Rebuilder {
     /**
      * Initialize the rebuilder, given the server configuration.
      *
-     * @returns a map of option names to plaintext descriptions.
      */
     public void setServerConfiguration(ServerConfiguration serverConfig);
 

--- a/fcrepo-server/src/main/java/org/fcrepo/server/utilities/rebuild/SQLRebuilder.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/utilities/rebuild/SQLRebuilder.java
@@ -100,7 +100,6 @@ public class SQLRebuilder
     /**
      * Initialize the rebuilder, given the server configuration.
      *
-     * @returns a map of option names to plaintext descriptions.
      */
     @Override
     public void setServerConfiguration(ServerConfiguration serverConfig) {

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/DOObjectValidator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/DOObjectValidator.java
@@ -25,8 +25,8 @@ public interface DOObjectValidator {
 	 * @param context
 	 * @param reader
 	 *            - DOReader wrapping the object
-	 * @throws ServerException. Throw
-	 *             an ObjectValidityException if something invalid is found
+	 * @throws ServerException
+	 *             Throws an ObjectValidityException if something invalid is found
 	 *             (with a useful message indicating what failed) and other
 	 *             types of ServerException if the validation process itself
 	 *             failed

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/DOValidatorImpl.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/DOValidatorImpl.java
@@ -125,7 +125,7 @@ public class DOValidatorImpl
      *        extension)
      * @param schematronPreprocessorPath
      *        Location of the Schematron pre-processing stylesheet configured
-     *        with Fedora.</i>
+     *        with Fedora.
      * @param ruleSchemaMap
      *        Location of rule schemas (Schematron), configured with Fedora (see
      *        Fedora.fcfg). Current options are <i>schematron/foxmlRules1-0.xml</i>

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/RelsValidator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/RelsValidator.java
@@ -91,6 +91,7 @@ import org.xml.sax.helpers.DefaultHandler;
  *        others from the <code>fedora-model</code> and <code>fedora-view</code>
  *        namespaces are inferred from values expressed elsewhere in the
  *        digital object, and we do not want duplication.
+ * </pre>
  * </li>
  * </ul>
  *

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/OwlValidator.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/OwlValidator.java
@@ -42,10 +42,9 @@ public class OwlValidator {
 
     /**
      * This is one complex method.
-     * <p/>
+     * <br>
      * 1. retrieve the list of content models from the object.
      * 2. retrieve the ontology datastreams from each of these content models
-     * 3.
      *
      * @param context
      * @param asOfDateTime

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/DsCompositeModel.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/DsCompositeModel.java
@@ -7,19 +7,19 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}dsTypeModel" maxOccurs="unbounded" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}dsTypeModel" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -34,21 +34,17 @@ public class DsCompositeModel {
 
     /**
      * Gets the value of the dsTypeModel property.
-     * <p/>
-     * <p/>
+     * <br>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the dsTypeModel property.
-     * <p/>
-     * <p/>
+     * <br>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getDsTypeModel().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <br>
      * Objects of the following type(s) are allowed in the list
      * {@link DsTypeModel }
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/DsTypeModel.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/DsTypeModel.java
@@ -7,22 +7,22 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}form" maxOccurs="unbounded" minOccurs="0"/>
- *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}extension" maxOccurs="unbounded" minOccurs="0"/>
- *       &lt;/sequence>
- *       &lt;attribute name="ID" use="required" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
- *       &lt;attribute name="optional" type="{http://www.w3.org/2001/XMLSchema}boolean" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}form" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element ref="{info:fedora/fedora-system:def/dsCompositeModel#}extension" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *       &lt;attribute name="ID" use="required" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" /&gt;
+ *       &lt;attribute name="optional" type="{http://www.w3.org/2001/XMLSchema}boolean" /&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -45,21 +45,17 @@ public class DsTypeModel {
 
     /**
      * Gets the value of the form property.
-     * <p/>
-     * <p/>
+     * <br>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the form property.
-     * <p/>
-     * <p/>
+     * <br>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getForm().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <br>
      * Objects of the following type(s) are allowed in the list
      * {@link Form }
      */
@@ -72,21 +68,17 @@ public class DsTypeModel {
 
     /**
      * Gets the value of the extension property.
-     * <p/>
-     * <p/>
+     * <br>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the extension property.
-     * <p/>
-     * <p/>
+     * <br>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getExtension().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <br>
      * Objects of the following type(s) are allowed in the list
      * {@link Extension }
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Extension.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Extension.java
@@ -9,20 +9,20 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any processContents='skip' maxOccurs="unbounded" minOccurs="0"/>
- *       &lt;/sequence>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any processContents='skip' maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" /&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -40,21 +40,17 @@ public class Extension {
 
     /**
      * Gets the value of the any property.
-     * <p/>
-     * <p/>
+     * <br>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     * <p/>
-     * <p/>
+     * <br>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getAny().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <br>
      * Objects of the following type(s) are allowed in the list
      * {@link Element }
      */

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Form.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Form.java
@@ -5,18 +5,18 @@ import javax.xml.bind.annotation.*;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;attribute name="FORMAT_URI" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *       &lt;attribute name="MIME" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;attribute name="FORMAT_URI" type="{http://www.w3.org/2001/XMLSchema}anyURI" /&gt;
+ *       &lt;attribute name="MIME" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" /&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Reference.java
+++ b/fcrepo-server/src/main/java/org/fcrepo/server/validation/ecm/jaxb/Reference.java
@@ -5,18 +5,18 @@ import javax.xml.bind.annotation.*;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;attribute name="type" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
- *       &lt;attribute name="datastream" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;attribute name="type" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" /&gt;
+ *       &lt;attribute name="datastream" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" /&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/fcrepo-server/src/test/java/org/fcrepo/server/resourceIndex/ParamDomain.java
+++ b/fcrepo-server/src/test/java/org/fcrepo/server/resourceIndex/ParamDomain.java
@@ -48,7 +48,7 @@ public class ParamDomain
      *        the parameter whose domain is being described.
      * @param isRequired
      *        whether specifying a value is required.
-     * @param values
+     * @param domainValues
      *        the domain values.
      */
     public ParamDomain(String parameterName,

--- a/fcrepo-server/src/test/java/org/fcrepo/server/storage/MockServiceDeploymentReader.java
+++ b/fcrepo-server/src/test/java/org/fcrepo/server/storage/MockServiceDeploymentReader.java
@@ -19,7 +19,7 @@ import org.fcrepo.server.storage.types.MethodParmDef;
 
 
 /**
- * A partial implementation of {@link BMechReader} for use in unit tests. Add
+ * A partial implementation of {@link ServiceDeploymentReader} for use in unit tests. Add
  * more mocking to this class as needed, or override methods in sub-classes.
  *
  * @author Jim Blake

--- a/fcrepo-server/src/test/java/org/fcrepo/server/storage/translation/TestDOTranslationUtility.java
+++ b/fcrepo-server/src/test/java/org/fcrepo/server/storage/translation/TestDOTranslationUtility.java
@@ -176,7 +176,7 @@ public class TestDOTranslationUtility {
 
     /**
      * Test method for
-     * {@link org.fcrepo.server.storage.translation.DOTranslationUtility#getAuditRecords(org.fcrepo.server.storage.types.Datastream)}.
+     * {@link org.fcrepo.server.storage.translation.DOTranslationUtility#getAuditRecords(java.io.InputStream)}.
      */
     @Test
     public void testGetAuditRecords() throws Exception {

--- a/fcrepo-webapp/fcrepo-webapp-democontent/src/main/webapp/document-transform-demo/Fedora-API-A.wsdl
+++ b/fcrepo-webapp/fcrepo-webapp-democontent/src/main/webapp/document-transform-demo/Fedora-API-A.wsdl
@@ -273,16 +273,15 @@
 		<operation name="getDissemination">
 			<http:operation location="getDissemination"/>
 			<input>
-				<http:urlEncoded>
-					<documentation>Inside the 'parameters' input message, 
-				          mechanism-specific parameters may be given.  When given as an HTTP 
-				          GET API-A request to Fedora, the mechanism-specific parameters are to 
-				          be further encoded in the HTTP GET request in the value of the 
-				          'parameters' message.  When demarshaling the request, the Fedora 
-				          server will un-URL-encode the the value of 'parameters', and pass the 
-				          provided value(s) to the underlying service.
-					</documentation>
-				</http:urlEncoded>
+				<documentation>Inside the 'parameters' input message, 
+			          mechanism-specific parameters may be given.  When given as an HTTP 
+			          GET API-A request to Fedora, the mechanism-specific parameters are to 
+			          be further encoded in the HTTP GET request in the value of the 
+			          'parameters' message.  When demarshaling the request, the Fedora 
+			          server will un-URL-encode the the value of 'parameters', and pass the 
+			          provided value(s) to the underlying service.
+				</documentation>
+				<http:urlEncoded/>
 			</input>
 			<output>
 				<mime:content type="*/*"/>

--- a/fcrepo-webapp/fcrepo-webapp-fedora/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/fcrepo-webapp-fedora/src/main/webapp/WEB-INF/web.xml
@@ -230,14 +230,6 @@
     <servlet-name>CXFSchemaServlet</servlet-name>
     <url-pattern>/schema/*</url-pattern>
   </servlet-mapping>
-  <filter>
-    <filter-name>RestApiFlashFilter</filter-name>
-    <filter-class>org.fcrepo.server.security.servletfilters.FilterRestApiFlash</filter-class>
-  </filter>
-  <filter-mapping>
-    <filter-name>RestApiFlashFilter</filter-name>
-    <servlet-name>RestServlet</servlet-name>
-  </filter-mapping>
 
   <!-- Spring security -->
   <filter>

--- a/fcrepo-webapp/fcrepo-webapp-imagemanip/src/main/webapp/index.html
+++ b/fcrepo-webapp/fcrepo-webapp-imagemanip/src/main/webapp/index.html
@@ -22,22 +22,22 @@
         Optional parameters that can be used to manipulate the image:
         <ul>
             <li><b>Resize:</b>&nbsp;&nbsp;&nbsp;
-                <b>op=resize&newWidth=&lt;width-in-pixels&gt;</b><br/>
+                <b>op=resize&amp;newWidth=&lt;width-in-pixels&gt;</b><br/>
                 This resizes an image to a specified width in pixels, automatically scaling the height in proportion to
                 the width.
             </li>
             <li><b>Zoom:</b>&nbsp;&nbsp;&nbsp;
-                <b>op=zoom&zoomAmt=&lt;zoom-value&gt;</b><br/>
+                <b>op=zoom&amp;zoomAmt=&lt;zoom-value&gt;</b><br/>
                 This zooms an image, depending on the zoom-value. 0 &lt; zoom-value &lt; 1 : zoom out, zoom-value=1 :
                 original, 1 &lt; zoom-value : zoom in
             </li>
             <li><b>Adjust Brightness:</b>&nbsp;&nbsp;&nbsp;
-                <b>op=brightness&brightAmt=&lt;bright-value&gt;</b><br/>
+                <b>op=brightness&amp;brightAmt=&lt;bright-value&gt;</b><br/>
                 This adjusts the brightness of an image, depending on the bright-value. 0 &lt;= bright-value &lt; 1 :
                 darkens, bright-value=1 : original, 1 &lt; bright-value : lightens
             </li>
             <li><b>Watermark:</b>&nbsp;&nbsp;&nbsp;
-                <b>op=watermark&wmText=&lt;watermark-text&gt;</b><br/>
+                <b>op=watermark&amp;wmText=&lt;watermark-text&gt;</b><br/>
                 Watermarks an image, with the supplied text.
             </li>
             <li><b>Grayscale:</b>&nbsp;&nbsp;&nbsp;
@@ -45,8 +45,8 @@
                 Converts an image to grayscale.
             </li>
             <li><b>Crop:</b>&nbsp;&nbsp;&nbsp;
-                <b>op=crop&cropX=&lt;crop-x&gt;&cropY=&lt;crop-y&gt;&<font
-                        color="#FF0000">cropWidth=&lt;crop-width&gt;</font>&<font color="#FF0000">cropHeight=&lt;crop-height&gt;</font></b><br/>
+                <b>op=crop&amp;cropX=&lt;crop-x&gt;&amp;cropY=&lt;crop-y&gt;&amp;<font
+                        color="#FF0000">cropWidth=&lt;crop-width&gt;</font>&amp;<font color="#FF0000">cropHeight=&lt;crop-height&gt;</font></b><br/>
                 Crops an image, starting from (crop-x,crop-y) coordinate, and crops to the optional
                 (crop-width,crop-height) coordinate if supplied, or just to the lower-right corner of the image. All
                 values are measured in pixels.
@@ -61,11 +61,11 @@
 <p><font color="#000000">Examples:</font></p>
 
 <p><font color="#000000"><a
-        href="/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=zoom&zoomAmt=2.5">/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=zoom&zoomAmt=2.5</a></font>
+        href="/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=zoom&zoomAmt=2.5">/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&amp;op=zoom&amp;zoomAmt=2.5</a></font>
 </p>
 
 <p><font color="#000000"><a
-        href="/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=convert&convertTo=gif">/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=convert&convertTo=gif</a></font>
+        href="/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&op=convert&convertTo=gif">/imagemanip/ImageManipulation?url=http://www.explore.cornell.edu/tour_landmarks/img/frosty_tower02.jpg&amp;op=convert&amp;convertTo=gif</a></font>
 </p>
 
 <p>&nbsp;</p>

--- a/pom.xml
+++ b/pom.xml
@@ -1327,6 +1327,11 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <maxmemory>128m</maxmemory>
+              <dependencySourceIncludes>
+                <!-- include ONLY duraspace project dependencies -->
+                <dependencySourceInclude>org.fcrepo:*</dependencySourceInclude>
+                <dependencySourceInclude>org.trippi:*</dependencySourceInclude>
+              </dependencySourceIncludes>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Fixes the javadoc errors provided the builder has a JAXB implementation >= 2.2.11, available in JDK8 via standards override. 